### PR TITLE
Fix backup location validation to coexist with registry dir.

### DIFF
--- a/pkg/persistence/object_store_layout.go
+++ b/pkg/persistence/object_store_layout.go
@@ -56,6 +56,9 @@ func (l *ObjectStoreLayout) GetResticDir() string {
 
 func (l *ObjectStoreLayout) isValidSubdir(name string) bool {
 	_, ok := l.subdirs[name]
+	if !ok {
+		return name == "registry"
+	}
 	return ok
 }
 


### PR DESCRIPTION
Velero backup location validation ensures that there isn't
non-velero content in the backup location. This commit makes
an exception for a top level registry/ dir to allow us to
use the same bucket for migration registry storage as we use
for the backups.