### PR TITLE
Adds support for allowing a RestoreItemAction to skip item restore

### DIFF
--- a/Dockerfile.el7
+++ b/Dockerfile.el7
@@ -1,0 +1,20 @@
+FROM openshift/origin-release:golang-1.11 AS builder
+COPY . /go/src/github.com/heptio/velero
+RUN cd /go/src/github.com/heptio/velero \
+&& CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' ./cmd/velero
+
+RUN mkdir /go/src/github.com/restic \
+&& cd /go/src/github.com/restic \
+&& git clone https://github.com/fusor/restic -b fusor-v0.9.4 \
+&& cd /go/src/github.com/restic/restic \
+&& CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' ./cmd/restic
+
+FROM centos:7
+RUN yum -y update && yum clean all
+
+COPY --from=builder /go/src/github.com/heptio/velero/velero velero
+COPY --from=builder /go/src/github.com/restic/restic/restic /usr/bin/restic
+
+USER nobody:nobody
+
+ENTRYPOINT ["/velero"]

--- a/pkg/controller/restore_controller.go
+++ b/pkg/controller/restore_controller.go
@@ -41,11 +41,11 @@ import (
 	"github.com/heptio/velero/pkg/metrics"
 	"github.com/heptio/velero/pkg/persistence"
 	"github.com/heptio/velero/pkg/plugin"
-	"github.com/heptio/velero/pkg/plugin/velero"
 	"github.com/heptio/velero/pkg/restore"
 	"github.com/heptio/velero/pkg/util/collections"
 	kubeutil "github.com/heptio/velero/pkg/util/kube"
 	"github.com/heptio/velero/pkg/util/logging"
+	"github.com/heptio/velero/pkg/volume"
 )
 
 // nonRestorableResources is a blacklist for the restoration process. Any resources
@@ -204,6 +204,40 @@ func (c *restoreController) processRestore(key string) error {
 	// don't modify items in the cache
 	restore = restore.DeepCopy()
 
+	// begin log setup from runRestore
+	var restoreWarnings, restoreErrors api.RestoreResult
+	var restoreFailure error
+	logFile, err := ioutil.TempFile("", "")
+	if err != nil {
+		c.logger.
+			WithFields(
+				logrus.Fields{
+					"restore": kubeutil.NamespaceAndName(restore),
+					"backup":  restore.Spec.BackupName,
+				},
+			).
+			WithError(errors.WithStack(err)).
+			Error("Error creating log temp file")
+		restoreFailure = err
+		restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
+	}
+	gzippedLogFile := gzip.NewWriter(logFile)
+	// Assuming we successfully uploaded the log file, this will have already been closed below. It is safe to call
+	// close multiple times. If we get an error closing this, there's not really anything we can do about it.
+	defer gzippedLogFile.Close()
+	defer closeAndRemoveFile(logFile, c.logger)
+
+	// Log the backup to both a backup log file and to stdout. This will help see what happened if the upload of the
+	// backup log failed for whatever reason.
+	logger := logging.DefaultLogger(c.restoreLogLevel)
+	logger.Out = io.MultiWriter(os.Stdout, gzippedLogFile)
+	log = logger.WithFields(
+		logrus.Fields{
+			"restore": kubeutil.NamespaceAndName(restore),
+			"backup":  restore.Spec.BackupName,
+		})
+	// end log setup from runRestore
+
 	pluginManager := c.newPluginManager(log)
 	defer pluginManager.CleanupClients()
 
@@ -241,22 +275,97 @@ func (c *restoreController) processRestore(key string) error {
 	log.Debug("Running restore")
 
 	// execution & upload of restore
-	restoreRes, restoreFailure := c.runRestore(
-		restore,
-		actions,
-		info,
-		pluginManager,
-	)
+	// begin runRestore
+	var backupFile, resultsFile *os.File
+	var volumeSnapshots []*volume.Snapshot
+	var gzippedResultsFile *gzip.Writer
+	if restoreFailure == nil {
+		backupFile, err = downloadToTempFile(restore.Spec.BackupName, info.backupStore, c.logger)
+		if err != nil {
+			log.WithError(err).Error("Error downloading backup")
+			restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
+			restoreFailure = err
+		}
+	}
+	if restoreFailure == nil {
+		defer closeAndRemoveFile(backupFile, c.logger)
 
+		resultsFile, err = ioutil.TempFile("", "")
+		if err != nil {
+			log.WithError(errors.WithStack(err)).Error("Error creating results temp file")
+			restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
+			restoreFailure = err
+		}
+	}
+	if restoreFailure == nil {
+		defer closeAndRemoveFile(resultsFile, c.logger)
+
+		volumeSnapshots, err = info.backupStore.GetBackupVolumeSnapshots(restore.Spec.BackupName)
+		if err != nil {
+			log.WithError(errors.WithStack(err)).Error("Error fetching volume snapshots")
+			restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
+			restoreFailure = err
+		}
+	}
+	// Any restoreFailure above this line means a total restore failure
+	// Some failures after this line *may* be a total restore failure
+	if restoreFailure == nil {
+		var stopWithoutFailure = false
+		log.Info("starting restore")
+		restoreWarnings, restoreErrors = c.restorer.Restore(log, restore, info.backup, volumeSnapshots, backupFile, actions, c.snapshotLocationLister, pluginManager)
+		log.Info("restore completed")
+
+		// Try to upload the log file. This is best-effort. If we fail, we'll add to the velero errors.
+		if err := gzippedLogFile.Close(); err != nil {
+			c.logger.WithError(err).Error("error closing gzippedLogFile")
+		}
+		// Reset the offset to 0 for reading
+		if _, err = logFile.Seek(0, 0); err != nil {
+			restoreErrors.Velero = append(restoreErrors.Velero, fmt.Sprintf("error resetting log file offset to 0: %v", err))
+			stopWithoutFailure = true
+		}
+
+		if !stopWithoutFailure {
+			if err := info.backupStore.PutRestoreLog(restore.Spec.BackupName, restore.Name, logFile); err != nil {
+				restoreErrors.Ark = append(restoreErrors.Ark, fmt.Sprintf("error uploading log file to backup storage: %v", err))
+			}
+
+			m := map[string]api.RestoreResult{
+				"warnings": restoreWarnings,
+				"errors":   restoreErrors,
+			}
+
+			gzippedResultsFile = gzip.NewWriter(resultsFile)
+
+			if err := json.NewEncoder(gzippedResultsFile).Encode(m); err != nil {
+				log.WithError(errors.WithStack(err)).Error("Error encoding restore results")
+				stopWithoutFailure = true
+			}
+		}
+		if !stopWithoutFailure {
+			gzippedResultsFile.Close()
+
+			if _, err = resultsFile.Seek(0, 0); err != nil {
+				log.WithError(errors.WithStack(err)).Error("Error resetting results file offset to 0")
+				stopWithoutFailure = true
+			}
+		}
+		if !stopWithoutFailure {
+			if err := info.backupStore.PutRestoreResults(restore.Spec.BackupName, restore.Name, resultsFile); err != nil {
+				log.WithError(errors.WithStack(err)).Error("Error uploading results file to backup storage")
+			}
+		}
+	}
+	// end runRestore
 	//TODO(1.0): Remove warnings.Ark
-	restore.Status.Warnings = len(restoreRes.warnings.Velero) + len(restoreRes.warnings.Cluster) + len(restoreRes.warnings.Ark)
-	for _, w := range restoreRes.warnings.Namespaces {
+	restore.Status.Warnings = len(restoreWarnings.Velero) + len(restoreWarnings.Cluster) + len(restoreWarnings.Ark)
+	for _, w := range restoreWarnings.Namespaces {
 		restore.Status.Warnings += len(w)
 	}
 
 	//TODO (1.0): Remove errors.Ark
-	restore.Status.Errors = len(restoreRes.errors.Velero) + len(restoreRes.errors.Cluster) + len(restoreRes.errors.Ark)
-	for _, e := range restoreRes.errors.Namespaces {
+	restore.Status.Errors = len(restoreErrors.Velero) + len(restoreErrors.Cluster) + len(restoreErrors.Ark)
+	for _, e := range restoreErrors.Namespaces {
 		restore.Status.Errors += len(e)
 	}
 
@@ -429,114 +538,6 @@ func (c *restoreController) fetchBackupInfo(backupName string, pluginManager plu
 		backup:      backup,
 		backupStore: backupStore,
 	}, nil
-}
-
-func (c *restoreController) runRestore(
-	restore *api.Restore,
-	actions []velero.RestoreItemAction,
-	info backupInfo,
-	pluginManager plugin.Manager,
-) (restoreResult, error) {
-	var restoreWarnings, restoreErrors api.RestoreResult
-	var restoreFailure error
-	logFile, err := ioutil.TempFile("", "")
-	if err != nil {
-		c.logger.
-			WithFields(
-				logrus.Fields{
-					"restore": kubeutil.NamespaceAndName(restore),
-					"backup":  restore.Spec.BackupName,
-				},
-			).
-			WithError(errors.WithStack(err)).
-			Error("Error creating log temp file")
-		restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-	gzippedLogFile := gzip.NewWriter(logFile)
-	// Assuming we successfully uploaded the log file, this will have already been closed below. It is safe to call
-	// close multiple times. If we get an error closing this, there's not really anything we can do about it.
-	defer gzippedLogFile.Close()
-	defer closeAndRemoveFile(logFile, c.logger)
-
-	// Log the backup to both a backup log file and to stdout. This will help see what happened if the upload of the
-	// backup log failed for whatever reason.
-	logger := logging.DefaultLogger(c.restoreLogLevel)
-	logger.Out = io.MultiWriter(os.Stdout, gzippedLogFile)
-	log := logger.WithFields(
-		logrus.Fields{
-			"restore": kubeutil.NamespaceAndName(restore),
-			"backup":  restore.Spec.BackupName,
-		})
-
-	backupFile, err := downloadToTempFile(restore.Spec.BackupName, info.backupStore, c.logger)
-	if err != nil {
-		log.WithError(err).Error("Error downloading backup")
-		restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
-		restoreFailure = err
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-	defer closeAndRemoveFile(backupFile, c.logger)
-
-	resultsFile, err := ioutil.TempFile("", "")
-	if err != nil {
-		log.WithError(errors.WithStack(err)).Error("Error creating results temp file")
-		restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
-		restoreFailure = err
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-	defer closeAndRemoveFile(resultsFile, c.logger)
-
-	volumeSnapshots, err := info.backupStore.GetBackupVolumeSnapshots(restore.Spec.BackupName)
-	if err != nil {
-		log.WithError(errors.WithStack(err)).Error("Error fetching volume snapshots")
-		restoreErrors.Velero = append(restoreErrors.Velero, err.Error())
-		restoreFailure = err
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-
-	// Any return statement above this line means a total restore failure
-	// Some failures after this line *may* be a total restore failure
-	log.Info("starting restore")
-	restoreWarnings, restoreErrors = c.restorer.Restore(log, restore, info.backup, volumeSnapshots, backupFile, actions, c.snapshotLocationLister, pluginManager)
-	log.Info("restore completed")
-
-	// Try to upload the log file. This is best-effort. If we fail, we'll add to the velero errors.
-	if err := gzippedLogFile.Close(); err != nil {
-		c.logger.WithError(err).Error("error closing gzippedLogFile")
-	}
-	// Reset the offset to 0 for reading
-	if _, err = logFile.Seek(0, 0); err != nil {
-		restoreErrors.Velero = append(restoreErrors.Velero, fmt.Sprintf("error resetting log file offset to 0: %v", err))
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-
-	if err := info.backupStore.PutRestoreLog(restore.Spec.BackupName, restore.Name, logFile); err != nil {
-		restoreErrors.Ark = append(restoreErrors.Ark, fmt.Sprintf("error uploading log file to backup storage: %v", err))
-	}
-
-	m := map[string]api.RestoreResult{
-		"warnings": restoreWarnings,
-		"errors":   restoreErrors,
-	}
-
-	gzippedResultsFile := gzip.NewWriter(resultsFile)
-
-	if err := json.NewEncoder(gzippedResultsFile).Encode(m); err != nil {
-		log.WithError(errors.WithStack(err)).Error("Error encoding restore results")
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-	gzippedResultsFile.Close()
-
-	if _, err = resultsFile.Seek(0, 0); err != nil {
-		log.WithError(errors.WithStack(err)).Error("Error resetting results file offset to 0")
-		return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
-	}
-	if err := info.backupStore.PutRestoreResults(restore.Spec.BackupName, restore.Name, resultsFile); err != nil {
-		log.WithError(errors.WithStack(err)).Error("Error uploading results file to backup storage")
-	}
-
-	return restoreResult{warnings: restoreWarnings, errors: restoreErrors}, restoreFailure
 }
 
 func downloadToTempFile(

--- a/pkg/persistence/object_store_layout.go
+++ b/pkg/persistence/object_store_layout.go
@@ -56,6 +56,9 @@ func (l *ObjectStoreLayout) GetResticDir() string {
 
 func (l *ObjectStoreLayout) isValidSubdir(name string) bool {
 	_, ok := l.subdirs[name]
+	if !ok {
+		return name == "registry"
+	}
 	return ok
 }
 

--- a/pkg/plugin/generated/RestoreItemAction.pb.go
+++ b/pkg/plugin/generated/RestoreItemAction.pb.go
@@ -58,8 +58,9 @@ func (m *RestoreExecuteRequest) GetItemFromBackup() []byte {
 }
 
 type RestoreExecuteResponse struct {
-	Item    []byte `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
-	Warning string `protobuf:"bytes,2,opt,name=warning" json:"warning,omitempty"`
+	Item        []byte `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
+	Warning     string `protobuf:"bytes,2,opt,name=warning" json:"warning,omitempty"`
+	SkipRestore bool   `protobuf:"varint,3,opt,name=skipRestore,proto3" json:"skipRestore,omitempty"`
 }
 
 func (m *RestoreExecuteResponse) Reset()                    { *m = RestoreExecuteResponse{} }
@@ -79,6 +80,13 @@ func (m *RestoreExecuteResponse) GetWarning() string {
 		return m.Warning
 	}
 	return ""
+}
+
+func (m *RestoreExecuteResponse) GetSkipRestore() bool {
+	if m != nil {
+		return m.SkipRestore
+	}
+	return false
 }
 
 func init() {

--- a/pkg/plugin/proto/RestoreItemAction.proto
+++ b/pkg/plugin/proto/RestoreItemAction.proto
@@ -13,6 +13,7 @@ message RestoreExecuteRequest {
 message RestoreExecuteResponse {
     bytes item = 1;
     string warning = 2;
+    bool skipRestore = 3;
 }
 
 service RestoreItemAction {

--- a/pkg/plugin/restore_item_action.go
+++ b/pkg/plugin/restore_item_action.go
@@ -126,6 +126,7 @@ func (c *RestoreItemActionGRPCClient) Execute(input *velero.RestoreItemActionExe
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem: &updatedItem,
 		Warning:     warning,
+		SkipRestore: res.SkipRestore,
 	}, nil
 }
 
@@ -235,7 +236,8 @@ func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *proto.Re
 	}
 
 	return &proto.RestoreExecuteResponse{
-		Item:    updatedItem,
-		Warning: warnMessage,
+		Item:        updatedItem,
+		Warning:     warnMessage,
+		SkipRestore: executeOutput.SkipRestore,
 	}, nil
 }

--- a/pkg/plugin/velero/restore_item_action.go
+++ b/pkg/plugin/velero/restore_item_action.go
@@ -55,6 +55,9 @@ type RestoreItemActionExecuteOutput struct {
 	// Warning is an exceptional message returned from ItemAction
 	// which is not preventing the item from being restored.
 	Warning error
+	// SkipRestore tells velero to stop executing further actions
+	// on this item, and skip the restore step.
+	SkipRestore bool
 }
 
 // NewRestoreItemActionExecuteOutput creates a new RestoreItemActionExecuteOutput
@@ -67,5 +70,11 @@ func NewRestoreItemActionExecuteOutput(item runtime.Unstructured) *RestoreItemAc
 // WithWarning returns a warning for RestoreItemActionExecuteOutput
 func (r *RestoreItemActionExecuteOutput) WithWarning(err error) *RestoreItemActionExecuteOutput {
 	r.Warning = err
+	return r
+}
+
+// WithoutRestore returns SkipRestore for RestoreItemActionExecuteOutput
+func (r *RestoreItemActionExecuteOutput) WithoutRestore() *RestoreItemActionExecuteOutput {
+	r.SkipRestore = true
 	return r
 }

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -700,6 +700,7 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 		applicableActions = append(applicableActions, action)
 	}
 
+fileLoop:
 	for _, file := range files {
 		fullPath := filepath.Join(resourcePath, file.Name())
 		obj, err := ctx.unmarshal(fullPath)
@@ -847,6 +848,10 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 				continue
 			}
 
+			if executeOutput.SkipRestore {
+				ctx.log.Infof("Skipping restore of %s: %v because a registered plugin discarded it", obj.GroupVersionKind().Kind, name)
+				continue fileLoop
+			}
 			unstructuredObj, ok := executeOutput.UpdatedItem.(*unstructured.Unstructured)
 			if !ok {
 				addToResult(&errs, namespace, fmt.Errorf("%s: unexpected type %T", fullPath, executeOutput.UpdatedItem))

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -700,7 +700,6 @@ func (ctx *context) restoreResource(resource, namespace, resourcePath string) (a
 		applicableActions = append(applicableActions, action)
 	}
 
-fileLoop:
 	for _, file := range files {
 		fullPath := filepath.Join(resourcePath, file.Name())
 		obj, err := ctx.unmarshal(fullPath)
@@ -848,15 +847,6 @@ fileLoop:
 				continue
 			}
 
-			abandon, err := abandonItem(executeOutput.UpdatedItem.(*unstructured.Unstructured))
-			if err != nil {
-				addToResult(&errs, namespace, fmt.Errorf("error preparing %s: %v", fullPath, err))
-				continue
-			}
-			if abandon {
-				ctx.log.Infof("Skipping restore of %s: %v because a registered plugin discarded it", obj.GroupVersionKind().Kind, name)
-				continue fileLoop
-			}
 			unstructuredObj, ok := executeOutput.UpdatedItem.(*unstructured.Unstructured)
 			if !ok {
 				addToResult(&errs, namespace, fmt.Errorf("%s: unexpected type %T", fullPath, executeOutput.UpdatedItem))
@@ -1054,20 +1044,6 @@ func isCompleted(obj *unstructured.Unstructured, groupResource schema.GroupResou
 	}
 	// Assume any other resource isn't complete and can be restored
 	return false, nil
-}
-
-// abandonItem returns whether or not a RestoreItemAction has decided to skip restore
-// Used to identify whether or not an object should be restored.
-func abandonItem(obj *unstructured.Unstructured) (bool, error) {
-	abandon, found, err := unstructured.NestedBool(obj.UnstructuredContent(), "abandonItem")
-	if err != nil {
-		return false, errors.WithStack(err)
-	}
-	if found {
-		return abandon, nil
-	} else {
-		return false, nil
-	}
 }
 
 // unmarshal reads the specified file, unmarshals the JSON contained within it


### PR DESCRIPTION
Adds support for allowing a RestoreItemAction to skip item restore
    
This allows a RestoreItemAction plugin to signal to velero that
the returned item should be skipped rather than restored to the
cluster.
    
To support this, a boolean SkipRestore attribute is added to
RestoreItemActionExecuteOutput. If restore.restoreResource finds
this set to true, any remaining actions on this item are skipped,
and restore on this item is skipped. Execution continues with
the next item of this resource type.
    
To signal this for a particular item, the RestoreItemAction's
Execute method should call WithoutRestore() on the
RestoreItemActionExecuteOutput before returning it.


The first commit reverts the commit from https://github.com/fusor/velero/pull/9
The second commit includes the changes for this feature.
The third commit includes the change to the autogenerated code -- generated by hack/generate-proto.sh but this commit only includes the changes relevant to the SkipRestore feature.