### PR TITLE
Adds support for allowing a RestoreItemAction to skip item restore

### DIFF
--- a/pkg/plugin/framework/restore_item_action_client.go
+++ b/pkg/plugin/framework/restore_item_action_client.go
@@ -117,5 +117,6 @@ func (c *RestoreItemActionGRPCClient) Execute(input *velero.RestoreItemActionExe
 	return &velero.RestoreItemActionExecuteOutput{
 		UpdatedItem:     &updatedItem,
 		AdditionalItems: additionalItems,
+		SkipRestore:     res.SkipRestore,
 	}, nil
 }

--- a/pkg/plugin/framework/restore_item_action_server.go
+++ b/pkg/plugin/framework/restore_item_action_server.go
@@ -116,17 +116,20 @@ func (s *RestoreItemActionGRPCServer) Execute(ctx context.Context, req *proto.Re
 	// If the plugin implementation returned a nil updateItem (meaning no modifications), reset updatedItem to the
 	// original item.
 	var updatedItemJSON []byte
+	skipRestore := false
 	if executeOutput.UpdatedItem == nil {
 		updatedItemJSON = req.Item
 	} else {
 		updatedItemJSON, err = json.Marshal(executeOutput.UpdatedItem.UnstructuredContent())
+		skipRestore = executeOutput.SkipRestore
 		if err != nil {
 			return nil, newGRPCError(errors.WithStack(err))
 		}
 	}
 
 	res := &proto.RestoreItemActionExecuteResponse{
-		Item: updatedItemJSON,
+		Item:        updatedItemJSON,
+		SkipRestore: skipRestore,
 	}
 
 	for _, item := range executeOutput.AdditionalItems {

--- a/pkg/plugin/generated/RestoreItemAction.pb.go
+++ b/pkg/plugin/generated/RestoreItemAction.pb.go
@@ -60,6 +60,7 @@ func (m *RestoreItemActionExecuteRequest) GetItemFromBackup() []byte {
 type RestoreItemActionExecuteResponse struct {
 	Item            []byte                `protobuf:"bytes,1,opt,name=item,proto3" json:"item,omitempty"`
 	AdditionalItems []*ResourceIdentifier `protobuf:"bytes,2,rep,name=additionalItems" json:"additionalItems,omitempty"`
+	SkipRestore     bool                  `protobuf:"varint,3,opt,name=skipRestore,proto3" json:"skipRestore,omitempty"`
 }
 
 func (m *RestoreItemActionExecuteResponse) Reset()         { *m = RestoreItemActionExecuteResponse{} }
@@ -81,6 +82,13 @@ func (m *RestoreItemActionExecuteResponse) GetAdditionalItems() []*ResourceIdent
 		return m.AdditionalItems
 	}
 	return nil
+}
+
+func (m *RestoreItemActionExecuteResponse) GetSkipRestore() bool {
+	if m != nil {
+		return m.SkipRestore
+	}
+	return false
 }
 
 func init() {

--- a/pkg/plugin/proto/RestoreItemAction.proto
+++ b/pkg/plugin/proto/RestoreItemAction.proto
@@ -13,6 +13,7 @@ message RestoreItemActionExecuteRequest {
 message RestoreItemActionExecuteResponse {
     bytes item = 1;
     repeated ResourceIdentifier additionalItems = 2;
+    bool skipRestore = 3;
 }
 
 service RestoreItemAction {

--- a/pkg/plugin/velero/restore_item_action.go
+++ b/pkg/plugin/velero/restore_item_action.go
@@ -57,6 +57,10 @@ type RestoreItemActionExecuteOutput struct {
 	// AdditionalItems is a list of additional related items that should
 	// be restored.
 	AdditionalItems []ResourceIdentifier
+
+	// SkipRestore tells velero to stop executing further actions
+	// on this item, and skip the restore step.
+	SkipRestore bool
 }
 
 // NewRestoreItemActionExecuteOutput creates a new RestoreItemActionExecuteOutput
@@ -64,4 +68,10 @@ func NewRestoreItemActionExecuteOutput(item runtime.Unstructured) *RestoreItemAc
 	return &RestoreItemActionExecuteOutput{
 		UpdatedItem: item,
 	}
+}
+
+// WithoutRestore returns SkipRestore for RestoreItemActionExecuteOutput
+func (r *RestoreItemActionExecuteOutput) WithoutRestore() *RestoreItemActionExecuteOutput {
+	r.SkipRestore = true
+	return r
 }

--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -896,6 +896,10 @@ func (ctx *context) restoreItem(obj *unstructured.Unstructured, groupResource sc
 			return warnings, errs
 		}
 
+		if executeOutput.SkipRestore {
+			ctx.log.Infof("Skipping restore of %s: %v because a registered plugin discarded it", obj.GroupVersionKind().Kind, name)
+			return warnings, errs
+		}
 		unstructuredObj, ok := executeOutput.UpdatedItem.(*unstructured.Unstructured)
 		if !ok {
 			addToResult(&errs, namespace, fmt.Errorf("%s: unexpected type %T", resourceID, executeOutput.UpdatedItem))


### PR DESCRIPTION
This allows a RestoreItemAction plugin to signal to velero that
the returned item should be skipped rather than restored to the
cluster.

To support this, a boolean SkipRestore attribute is added to
RestoreItemActionExecuteOutput. If restore.restoreResource finds
this set to true, any remaining actions on this item are skipped,
and restore on this item is skipped. Execution continues with
the next item of this resource type.

To signal this for a particular item, the RestoreItemAction's
Execute method should call WithoutRestore() on the
RestoreItemActionExecuteOutput before returning it.
