### PR TITLE
Revert "Fix backup location validation to coexist with registry dir."

### DIFF
--- a/pkg/persistence/object_store_layout.go
+++ b/pkg/persistence/object_store_layout.go
@@ -56,9 +56,6 @@ func (l *ObjectStoreLayout) GetResticDir() string {
 
 func (l *ObjectStoreLayout) isValidSubdir(name string) bool {
 	_, ok := l.subdirs[name]
-	if !ok {
-		return name == "registry"
-	}
 	return ok
 }
 


### PR DESCRIPTION
This reverts commit 02d508632a11918741e1132838b325d4fceb6fbd.

Once https://github.com/fusor/ocp-velero-ansible/pull/15 is merged, we won't need this validation exception anymore. The reverted commit makes an exception for the "registry" dir when it disallows any non-velero top-level directories on startup validation. With the referenced configuration change, we'll be configuring velero's BackupStorageLocation with a prefix, so velero and docker paths won't conflict.