### PR TITLE
use ubi8-minimal

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -9,8 +9,8 @@ RUN mkdir /go/src/github.com/restic \
 && cd /go/src/github.com/restic/restic \
 && CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' ./cmd/restic
 
-FROM centos:7
-RUN yum -y update && yum clean all
+FROM registry.access.redhat.com/ubi8-minimal
+RUN microdnf -y update && microdnf clean all
 
 COPY --from=builder /go/src/github.com/heptio/velero/velero velero
 COPY --from=builder /go/src/github.com/restic/restic/restic /usr/bin/restic


### PR DESCRIPTION
Because of the Dockerfile rename this will require fixing the build triggers on Quay.