### PR TITLE
Fix custom restic-restore-helper image not being used

### DIFF
--- a/pkg/apis/velero/v1/constants.go
+++ b/pkg/apis/velero/v1/constants.go
@@ -19,7 +19,7 @@ package v1
 const (
 	// DefaultNamespace is the Kubernetes namespace that is used by default for
 	// the Velero server and API objects.
-	DefaultNamespace = "velero"
+	DefaultNamespace = "openshift-migration"
 
 	// ResourcesDir is a top-level directory expected in backups which contains sub-directories
 	// for each resource type in the backup.

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -156,20 +156,22 @@ func getImage(log logrus.FieldLogger, config *corev1.ConfigMap) string {
 
 	log = log.WithField("image", image)
 
-	parts := strings.Split(image, ":")
-	switch {
-	case len(parts) == 1:
+	parts := strings.Split(image, "/")
+
+	if len(parts) == 1 {
+		// Image supplied without registry part
+		log.Debugf("Plugin config contains image name without registry name. Return defaultImageBase")
+		return initContainerImage(defaultImageBase)
+	}
+
+	if !(strings.Contains(parts[len(parts)-1], ":")) {
 		// tag-less image name: add tag
 		log.Debugf("Plugin config contains image name without tag. Adding tag.")
 		return initContainerImage(image)
-	case len(parts) == 2:
+	} else {
 		// tagged image name
 		log.Debugf("Plugin config contains image name with tag")
 		return image
-	default:
-		// unrecognized
-		log.Warnf("Plugin config contains unparseable image name")
-		return initContainerImage(defaultImageBase)
 	}
 }
 


### PR DESCRIPTION
@sseago @dymurray can you help me get this merged to the correct branch for 1.0.1?

There are two issues. Because we went downt he route of installing velero in a custom namespaces the DefaultNamespace being used to lookup configuration is wrong and velero never finds the configmap.

The second issue is that when found we get an error message that the image is unparseable because the original code does not account for a registry with the port specified.

This was reported and fixed in velero and I have the same fix here, which resolves the problem, even though it is not particularly suited to using SHAs:
https://github.com/vmware-tanzu/velero/issues/1972
https://github.com/vmware-tanzu/velero/pull/1999