### PR TITLE
Pass s3 BSL insecureSkipTLSVerify flag through to Restic

### DIFF
--- a/pkg/controller/pod_volume_backup_controller.go
+++ b/pkg/controller/pod_volume_backup_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -235,7 +236,20 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 		}
 		resticCmd.Env = env
 	}
-
+	var insecureSkipTLSVerify bool
+	if strings.HasPrefix(req.Spec.RepoIdentifier, "s3") {
+		bsl, err := c.backupLocationLister.BackupStorageLocations(req.Namespace).Get(req.Spec.BackupStorageLocation)
+		if err != nil {
+			log.WithError(err).Errorf("Error getting BackupStorageLocation %s", req.Spec.BackupStorageLocation)
+			return errors.WithStack(err)
+		}
+		insecureSkipTLSVerify, err = strconv.ParseBool(bsl.Spec.Config["insecureSkipTLSVerify"])
+		if err != nil {
+			log.WithError(err).Error("error parsing insecureSkipTLSVerify (expected bool)")
+			return errors.WithStack(err)
+		}
+		resticCmd.InsecureSkipTLSVerify = insecureSkipTLSVerify
+	}
 	// If this is a PVC, look for the most recent completed pod volume backup for it and get
 	// its restic snapshot ID to use as the value of the `--parent` flag. Without this,
 	// if the pod using the PVC (and therefore the directory path under /host_pods/) has
@@ -266,7 +280,7 @@ func (c *podVolumeBackupController) processBackup(req *velerov1api.PodVolumeBack
 
 	var snapshotID string
 	if !emptySnapshot {
-		snapshotID, err = restic.GetSnapshotID(req.Spec.RepoIdentifier, file, req.Spec.Tags, env)
+		snapshotID, err = restic.GetSnapshotID(req.Spec.RepoIdentifier, file, req.Spec.Tags, env, insecureSkipTLSVerify)
 		if err != nil {
 			log.WithError(err).Error("Error getting SnapshotID")
 			return c.fail(req, errors.Wrap(err, "error getting snapshot id").Error(), log)

--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
@@ -335,6 +336,19 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 			return c.failRestore(req, errors.Wrap(err, "error setting restic cmd env").Error(), log)
 		}
 		resticCmd.Env = env
+	}
+	if strings.HasPrefix(req.Spec.RepoIdentifier, "s3") {
+		bsl, err := c.backupLocationLister.BackupStorageLocations(req.Namespace).Get(req.Spec.BackupStorageLocation)
+		if err != nil {
+			log.WithError(err).Errorf("Error getting BackupStorageLocation %s", req.Spec.BackupStorageLocation)
+			return errors.WithStack(err)
+		}
+		insecureSkipTLSVerify, err := strconv.ParseBool(bsl.Spec.Config["insecureSkipTLSVerify"])
+		if err != nil {
+			log.WithError(err).Error("error parsing insecureSkipTLSVerify (expected bool)")
+			return errors.WithStack(err)
+		}
+		resticCmd.InsecureSkipTLSVerify = insecureSkipTLSVerify
 	}
 
 	var stdout, stderr string

--- a/pkg/restic/command.go
+++ b/pkg/restic/command.go
@@ -26,13 +26,14 @@ import (
 
 // Command represents a restic command.
 type Command struct {
-	Command        string
-	RepoIdentifier string
-	PasswordFile   string
-	Dir            string
-	Args           []string
-	ExtraFlags     []string
-	Env            []string
+	Command               string
+	RepoIdentifier        string
+	PasswordFile          string
+	Dir                   string
+	Args                  []string
+	ExtraFlags            []string
+	Env                   []string
+	InsecureSkipTLSVerify bool
 }
 
 func (c *Command) RepoName() string {
@@ -50,6 +51,9 @@ func (c *Command) StringSlice() []string {
 	res = append(res, c.Command, repoFlag(c.RepoIdentifier))
 	if c.PasswordFile != "" {
 		res = append(res, passwordFlag(c.PasswordFile))
+	}
+	if c.InsecureSkipTLSVerify {
+		res = append(res, "--insecure-skip-tls-verify")
 	}
 
 	// If VELERO_SCRATCH_DIR is defined, put the restic cache within it. If not,

--- a/pkg/restic/exec_commands.go
+++ b/pkg/restic/exec_commands.go
@@ -47,11 +47,12 @@ type backupStatusLine struct {
 // GetSnapshotID runs a 'restic snapshots' command to get the ID of the snapshot
 // in the specified repo matching the set of provided tags, or an error if a
 // unique snapshot cannot be identified.
-func GetSnapshotID(repoIdentifier, passwordFile string, tags map[string]string, env []string) (string, error) {
+func GetSnapshotID(repoIdentifier, passwordFile string, tags map[string]string, env []string, insecureSkipTLSVerify bool) (string, error) {
 	cmd := GetSnapshotCommand(repoIdentifier, passwordFile, tags)
 	if len(env) > 0 {
 		cmd.Env = env
 	}
+	cmd.InsecureSkipTLSVerify = insecureSkipTLSVerify
 
 	stdout, stderr, err := exec.RunCommand(cmd.Cmd())
 	if err != nil {

--- a/pkg/restic/repository_manager.go
+++ b/pkg/restic/repository_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -244,16 +245,26 @@ func (rm *repositoryManager) exec(cmd *Command, backupLocation string) error {
 
 	cmd.PasswordFile = file
 
+	if !cache.WaitForCacheSync(rm.ctx.Done(), rm.backupLocationInformerSynced) {
+		return errors.New("timed out waiting for cache to sync")
+	}
 	if strings.HasPrefix(cmd.RepoIdentifier, "azure") {
-		if !cache.WaitForCacheSync(rm.ctx.Done(), rm.backupLocationInformerSynced) {
-			return errors.New("timed out waiting for cache to sync")
-		}
-
 		env, err := AzureCmdEnv(rm.backupLocationLister, rm.namespace, backupLocation)
 		if err != nil {
 			return err
 		}
 		cmd.Env = env
+	}
+	if strings.HasPrefix(cmd.RepoIdentifier, "s3") {
+		bsl, err := rm.backupLocationLister.BackupStorageLocations(rm.namespace).Get(backupLocation)
+		if err != nil {
+			return err
+		}
+		insecureSkipTLSVerify, err := strconv.ParseBool(bsl.Spec.Config["insecureSkipTLSVerify"])
+		if err != nil {
+			return err
+		}
+		cmd.InsecureSkipTLSVerify = insecureSkipTLSVerify
 	}
 
 	stdout, stderr, err := veleroexec.RunCommand(cmd.Cmd())


### PR DESCRIPTION
Velero 1.2.0 and the plugin for AWS have support for a flag named insecureSkipTLSVerify. This PR would allow Velero's Restic integration to support that as well, in conjunction with https://github.com/fusor/restic/pull/3

See also: https://github.com/vmware-tanzu/velero/pull/1793/files
