### PR TITLE
[WIP] Update tests for modified default namespace

### DIFF
--- a/pkg/backup/service_account_action_test.go
+++ b/pkg/backup/service_account_action_test.go
@@ -209,7 +209,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -224,7 +224,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -239,7 +239,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 						},
 						{
 							Kind:      "non-matching-kind",
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 						{
@@ -249,7 +249,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 						},
 						{
 							Kind:      rbac.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "non-matching-name",
 						},
 					},
@@ -267,7 +267,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -300,7 +300,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 						},
 						{
 							Kind:      rbac.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 					},
@@ -315,7 +315,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 					Subjects: []rbac.Subject{
 						{
 							Kind:      rbac.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 					},
@@ -330,7 +330,7 @@ func TestServiceAccountActionExecute(t *testing.T) {
 					Subjects: []rbac.Subject{
 						{
 							Kind:      rbac.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 						{
@@ -417,7 +417,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -432,7 +432,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -447,7 +447,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 						},
 						{
 							Kind:      "non-matching-kind",
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 						{
@@ -457,7 +457,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 						},
 						{
 							Kind:      rbacbeta.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "non-matching-name",
 						},
 					},
@@ -475,7 +475,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 				"apiVersion": "v1",
 				"kind": "ServiceAccount",
 				"metadata": {
-					"namespace": "velero",
+					"namespace": "openshift-migration",
 					"name": "velero"
 				}
 			}
@@ -508,7 +508,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 						},
 						{
 							Kind:      rbacbeta.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 					},
@@ -523,7 +523,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 					Subjects: []rbacbeta.Subject{
 						{
 							Kind:      rbacbeta.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 					},
@@ -538,7 +538,7 @@ func TestServiceAccountActionExecuteOnBeta1(t *testing.T) {
 					Subjects: []rbacbeta.Subject{
 						{
 							Kind:      rbacbeta.ServiceAccountKind,
-							Namespace: "velero",
+							Namespace: "openshift-migration",
 							Name:      "velero",
 						},
 						{

--- a/pkg/controller/backup_controller_test.go
+++ b/pkg/controller/backup_controller_test.go
@@ -76,22 +76,22 @@ func TestProcessBackupNonProcessedItems(t *testing.T) {
 		},
 		{
 			name:   "FailedValidation backup is not processed",
-			key:    "velero/backup-1",
+			key:    "openshift-migration/backup-1",
 			backup: defaultBackup().Phase(velerov1api.BackupPhaseFailedValidation).Result(),
 		},
 		{
 			name:   "InProgress backup is not processed",
-			key:    "velero/backup-1",
+			key:    "openshift-migration/backup-1",
 			backup: defaultBackup().Phase(velerov1api.BackupPhaseInProgress).Result(),
 		},
 		{
 			name:   "Completed backup is not processed",
-			key:    "velero/backup-1",
+			key:    "openshift-migration/backup-1",
 			backup: defaultBackup().Phase(velerov1api.BackupPhaseCompleted).Result(),
 		},
 		{
 			name:   "Failed backup is not processed",
-			key:    "velero/backup-1",
+			key:    "openshift-migration/backup-1",
 			backup: defaultBackup().Phase(velerov1api.BackupPhaseFailed).Result(),
 		},
 	}
@@ -126,7 +126,7 @@ func TestProcessBackupNonProcessedItems(t *testing.T) {
 }
 
 func TestProcessBackupValidationFailures(t *testing.T) {
-	defaultBackupLocation := builder.ForBackupStorageLocation("velero", "loc-1").Result()
+	defaultBackupLocation := builder.ForBackupStorageLocation("openshift-migration", "loc-1").Result()
 
 	tests := []struct {
 		name           string
@@ -154,7 +154,7 @@ func TestProcessBackupValidationFailures(t *testing.T) {
 		{
 			name:           "backup for read-only backup location fails validation",
 			backup:         defaultBackup().StorageLocation("read-only").Result(),
-			backupLocation: builder.ForBackupStorageLocation("velero", "read-only").AccessMode(velerov1api.BackupStorageLocationAccessModeReadOnly).Result(),
+			backupLocation: builder.ForBackupStorageLocation("openshift-migration", "read-only").AccessMode(velerov1api.BackupStorageLocationAccessModeReadOnly).Result(),
 			expectedErrs:   []string{"backup can't be created because backup storage location read-only is currently in read-only mode"},
 		},
 	}
@@ -215,13 +215,13 @@ func TestBackupLocationLabel(t *testing.T) {
 		{
 			name:                   "valid backup location name should be used as a label",
 			backup:                 defaultBackup().Result(),
-			backupLocation:         builder.ForBackupStorageLocation("velero", "loc-1").Result(),
+			backupLocation:         builder.ForBackupStorageLocation("openshift-migration", "loc-1").Result(),
 			expectedBackupLocation: "loc-1",
 		},
 		{
 			name:                   "invalid storage location name should be handled while creating label",
 			backup:                 defaultBackup().Result(),
-			backupLocation:         builder.ForBackupStorageLocation("velero", "defaultdefaultdefaultdefaultdefaultdefaultdefaultdefaultdefaultdefault").Result(),
+			backupLocation:         builder.ForBackupStorageLocation("openshift-migration", "defaultdefaultdefaultdefaultdefaultdefaultdefaultdefaultdefaultdefault").Result(),
 			expectedBackupLocation: "defaultdefaultdefaultdefaultdefaultdefaultdefaultdefaultd58343f",
 		},
 	}
@@ -311,7 +311,7 @@ func TestDefaultBackupTTL(t *testing.T) {
 }
 
 func TestProcessBackupCompletions(t *testing.T) {
-	defaultBackupLocation := builder.ForBackupStorageLocation("velero", "loc-1").Bucket("store-1").Result()
+	defaultBackupLocation := builder.ForBackupStorageLocation("openshift-migration", "loc-1").Bucket("store-1").Result()
 
 	now, err := time.Parse(time.RFC1123Z, time.RFC1123Z)
 	require.NoError(t, err)
@@ -358,7 +358,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 		{
 			name:           "backup with a specific backup location keeps it",
 			backup:         defaultBackup().StorageLocation("alt-loc").Result(),
-			backupLocation: builder.ForBackupStorageLocation("velero", "alt-loc").Bucket("store-1").Result(),
+			backupLocation: builder.ForBackupStorageLocation("openshift-migration", "alt-loc").Bucket("store-1").Result(),
 			expectedResult: &velerov1api.Backup{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Backup",
@@ -386,7 +386,7 @@ func TestProcessBackupCompletions(t *testing.T) {
 		{
 			name:   "backup for a location with ReadWrite access mode gets processed",
 			backup: defaultBackup().StorageLocation("read-write").Result(),
-			backupLocation: builder.ForBackupStorageLocation("velero", "read-write").
+			backupLocation: builder.ForBackupStorageLocation("openshift-migration", "read-write").
 				Bucket("store-1").
 				AccessMode(velerov1api.BackupStorageLocationAccessModeReadWrite).
 				Result(),

--- a/pkg/controller/backup_deletion_controller_test.go
+++ b/pkg/controller/backup_deletion_controller_test.go
@@ -124,7 +124,7 @@ type backupDeletionControllerTestData struct {
 
 func setupBackupDeletionControllerTest(objects ...runtime.Object) *backupDeletionControllerTestData {
 	req := pkgbackup.NewDeleteBackupRequest("foo", "uid")
-	req.Namespace = "velero"
+	req.Namespace = "openshift-migration"
 	req.Name = "foo-abcde"
 
 	var (
@@ -268,7 +268,7 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 
 	t.Run("patching to InProgress fails", func(t *testing.T) {
 		backup := builder.ForBackup(v1.DefaultNamespace, "foo").StorageLocation("default").Result()
-		location := builder.ForBackupStorageLocation("velero", "default").Result()
+		location := builder.ForBackupStorageLocation("openshift-migration", "default").Result()
 
 		td := setupBackupDeletionControllerTest(backup)
 
@@ -300,7 +300,7 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 
 	t.Run("patching backup to Deleting fails", func(t *testing.T) {
 		backup := builder.ForBackup(v1.DefaultNamespace, "foo").StorageLocation("default").Result()
-		location := builder.ForBackupStorageLocation("velero", "default").Result()
+		location := builder.ForBackupStorageLocation("openshift-migration", "default").Result()
 
 		td := setupBackupDeletionControllerTest(backup)
 
@@ -392,7 +392,7 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 
 	t.Run("backup storage location is in read-only mode", func(t *testing.T) {
 		backup := builder.ForBackup(v1.DefaultNamespace, "foo").StorageLocation("default").Result()
-		location := builder.ForBackupStorageLocation("velero", "default").AccessMode(v1.BackupStorageLocationAccessModeReadOnly).Result()
+		location := builder.ForBackupStorageLocation("openshift-migration", "default").AccessMode(v1.BackupStorageLocationAccessModeReadOnly).Result()
 
 		td := setupBackupDeletionControllerTest(backup)
 
@@ -424,9 +424,9 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 		backup.UID = "uid"
 		backup.Spec.StorageLocation = "primary"
 
-		restore1 := builder.ForRestore("velero", "restore-1").Phase(v1.RestorePhaseCompleted).Backup("foo").Result()
-		restore2 := builder.ForRestore("velero", "restore-2").Phase(v1.RestorePhaseCompleted).Backup("foo").Result()
-		restore3 := builder.ForRestore("velero", "restore-3").Phase(v1.RestorePhaseCompleted).Backup("some-other-backup").Result()
+		restore1 := builder.ForRestore("openshift-migration", "restore-1").Phase(v1.RestorePhaseCompleted).Backup("foo").Result()
+		restore2 := builder.ForRestore("openshift-migration", "restore-2").Phase(v1.RestorePhaseCompleted).Backup("foo").Result()
+		restore3 := builder.ForRestore("openshift-migration", "restore-3").Phase(v1.RestorePhaseCompleted).Backup("some-other-backup").Result()
 
 		td := setupBackupDeletionControllerTest(backup, restore1, restore2, restore3)
 
@@ -574,22 +574,22 @@ func TestBackupDeletionControllerProcessRequest(t *testing.T) {
 		backup.UID = "uid"
 		backup.Spec.StorageLocation = "primary"
 
-		restore1 := builder.ForRestore("velero", "restore-1").
+		restore1 := builder.ForRestore("openshift-migration", "restore-1").
 			Phase(v1.RestorePhaseCompleted).
 			Backup("the-really-long-backup-name-that-is-much-more-than-63-characters").
 			Result()
-		restore2 := builder.ForRestore("velero", "restore-2").
+		restore2 := builder.ForRestore("openshift-migration", "restore-2").
 			Phase(v1.RestorePhaseCompleted).
 			Backup("the-really-long-backup-name-that-is-much-more-than-63-characters").
 			Result()
-		restore3 := builder.ForRestore("velero", "restore-3").
+		restore3 := builder.ForRestore("openshift-migration", "restore-3").
 			Phase(v1.RestorePhaseCompleted).
 			Backup("some-other-backup").
 			Result()
 
 		td := setupBackupDeletionControllerTest(backup, restore1, restore2, restore3)
 		td.req = pkgbackup.NewDeleteBackupRequest(backup.Name, string(backup.UID))
-		td.req.Namespace = "velero"
+		td.req.Namespace = "openshift-migration"
 		td.req.Name = "foo-abcde"
 		td.sharedInformers.Velero().V1().Restores().Informer().GetStore().Add(restore1)
 		td.sharedInformers.Velero().V1().Restores().Informer().GetStore().Add(restore2)

--- a/pkg/controller/backup_sync_controller_test.go
+++ b/pkg/controller/backup_sync_controller_test.go
@@ -146,8 +146,8 @@ func TestBackupSyncControllerRun(t *testing.T) {
 		},
 		{
 			name:      "all synced backups get created in Velero server's namespace",
-			namespace: "velero",
-			locations: defaultLocationsList("velero"),
+			namespace: "openshift-migration",
+			locations: defaultLocationsList("openshift-migration"),
 			cloudBuckets: map[string][]*cloudBackupData{
 				"bucket-1": {
 					&cloudBackupData{
@@ -162,7 +162,7 @@ func TestBackupSyncControllerRun(t *testing.T) {
 						backup: builder.ForBackup("ns-2", "backup-3").Result(),
 					},
 					&cloudBackupData{
-						backup: builder.ForBackup("velero", "backup-4").Result(),
+						backup: builder.ForBackup("openshift-migration", "backup-4").Result(),
 					},
 				},
 			},

--- a/pkg/controller/gc_controller_test.go
+++ b/pkg/controller/gc_controller_test.go
@@ -152,7 +152,7 @@ func TestGCControllerHasUpdateFunc(t *testing.T) {
 
 func TestGCControllerProcessQueueItem(t *testing.T) {
 	fakeClock := clock.NewFakeClock(time.Now())
-	defaultBackupLocation := builder.ForBackupStorageLocation("velero", "default").Result()
+	defaultBackupLocation := builder.ForBackupStorageLocation("openshift-migration", "default").Result()
 
 	tests := []struct {
 		name                           string
@@ -175,13 +175,13 @@ func TestGCControllerProcessQueueItem(t *testing.T) {
 		{
 			name:           "expired backup in read-only storage location is not deleted",
 			backup:         defaultBackup().Expiration(fakeClock.Now().Add(-time.Minute)).StorageLocation("read-only").Result(),
-			backupLocation: builder.ForBackupStorageLocation("velero", "read-only").AccessMode(api.BackupStorageLocationAccessModeReadOnly).Result(),
+			backupLocation: builder.ForBackupStorageLocation("openshift-migration", "read-only").AccessMode(api.BackupStorageLocationAccessModeReadOnly).Result(),
 			expectDeletion: false,
 		},
 		{
 			name:           "expired backup in read-write storage location is deleted",
 			backup:         defaultBackup().Expiration(fakeClock.Now().Add(-time.Minute)).StorageLocation("read-write").Result(),
-			backupLocation: builder.ForBackupStorageLocation("velero", "read-write").AccessMode(api.BackupStorageLocationAccessModeReadWrite).Result(),
+			backupLocation: builder.ForBackupStorageLocation("openshift-migration", "read-write").AccessMode(api.BackupStorageLocationAccessModeReadWrite).Result(),
 			expectDeletion: true,
 		},
 		{

--- a/pkg/controller/restore_controller_test.go
+++ b/pkg/controller/restore_controller_test.go
@@ -65,7 +65,7 @@ func TestFetchBackupInfo(t *testing.T) {
 		{
 			name:              "lister has backup",
 			backupName:        "backup-1",
-			informerLocations: []*api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
+			informerLocations: []*api.BackupStorageLocation{builder.ForBackupStorageLocation("openshift-migration", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*api.Backup{defaultBackup().StorageLocation("default").Result()},
 			expectedRes:       defaultBackup().StorageLocation("default").Result(),
 		},
@@ -73,7 +73,7 @@ func TestFetchBackupInfo(t *testing.T) {
 			name:              "lister does not have a backup, but backupSvc does",
 			backupName:        "backup-1",
 			backupStoreBackup: defaultBackup().StorageLocation("default").Result(),
-			informerLocations: []*api.BackupStorageLocation{builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()},
+			informerLocations: []*api.BackupStorageLocation{builder.ForBackupStorageLocation("openshift-migration", "default").Provider("myCloud").Bucket("bucket").Result()},
 			informerBackups:   []*api.Backup{defaultBackup().StorageLocation("default").Result()},
 			expectedRes:       defaultBackup().StorageLocation("default").Result(),
 		},
@@ -226,7 +226,7 @@ func TestProcessQueueItemSkips(t *testing.T) {
 }
 
 func TestProcessQueueItem(t *testing.T) {
-	defaultStorageLocation := builder.ForBackupStorageLocation("velero", "default").Provider("myCloud").Bucket("bucket").Result()
+	defaultStorageLocation := builder.ForBackupStorageLocation("openshift-migration", "default").Provider("myCloud").Bucket("bucket").Result()
 
 	tests := []struct {
 		name                            string

--- a/pkg/install/resources_test.go
+++ b/pkg/install/resources_test.go
@@ -23,29 +23,29 @@ import (
 )
 
 func TestResources(t *testing.T) {
-	bsl := BackupStorageLocation("velero", "test", "test", "", make(map[string]string))
+	bsl := BackupStorageLocation("openshift-migration", "test", "test", "", make(map[string]string))
 
-	assert.Equal(t, "velero", bsl.ObjectMeta.Namespace)
+	assert.Equal(t, "openshift-migration", bsl.ObjectMeta.Namespace)
 	assert.Equal(t, "test", bsl.Spec.Provider)
 	assert.Equal(t, "test", bsl.Spec.StorageType.ObjectStorage.Bucket)
 	assert.Equal(t, make(map[string]string), bsl.Spec.Config)
 
-	vsl := VolumeSnapshotLocation("velero", "test", make(map[string]string))
+	vsl := VolumeSnapshotLocation("openshift-migration", "test", make(map[string]string))
 
-	assert.Equal(t, "velero", vsl.ObjectMeta.Namespace)
+	assert.Equal(t, "openshift-migration", vsl.ObjectMeta.Namespace)
 	assert.Equal(t, "test", vsl.Spec.Provider)
 	assert.Equal(t, make(map[string]string), vsl.Spec.Config)
 
-	ns := Namespace("velero")
+	ns := Namespace("openshift-migration")
 
-	assert.Equal(t, "velero", ns.Name)
+	assert.Equal(t, "openshift-migration", ns.Name)
 
-	crb := ClusterRoleBinding("velero")
+	crb := ClusterRoleBinding("openshift-migration")
 	// The CRB is a cluster-scoped resource
 	assert.Equal(t, "", crb.ObjectMeta.Namespace)
-	assert.Equal(t, "velero", crb.Subjects[0].Namespace)
+	assert.Equal(t, "openshift-migration", crb.Subjects[0].Namespace)
 
-	sa := ServiceAccount("velero", map[string]string{"abcd": "cbd"})
-	assert.Equal(t, "velero", sa.ObjectMeta.Namespace)
+	sa := ServiceAccount("openshift-migration", map[string]string{"abcd": "cbd"})
+	assert.Equal(t, "openshift-migration", sa.ObjectMeta.Namespace)
 	assert.Equal(t, "cbd", sa.ObjectMeta.Annotations["abcd"])
 }

--- a/pkg/restic/common_test.go
+++ b/pkg/restic/common_test.go
@@ -75,8 +75,8 @@ func TestGetVolumeBackupsForPod(t *testing.T) {
 		{
 			name: "has snapshot annotation, with suffix, and also PVBs",
 			podVolumeBackups: []*velerov1api.PodVolumeBackup{
-				builder.ForPodVolumeBackup("velero", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
 			},
 			podName:        "TestPod",
 			podAnnotations: map[string]string{"x": "y", podAnnotationPrefix + "foo": "bar", podAnnotationPrefix + "abc": "123"},
@@ -85,8 +85,8 @@ func TestGetVolumeBackupsForPod(t *testing.T) {
 		{
 			name: "no snapshot annotation, but with PVBs",
 			podVolumeBackups: []*velerov1api.PodVolumeBackup{
-				builder.ForPodVolumeBackup("velero", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
 			},
 			podName:  "TestPod",
 			expected: map[string]string{"pvbtest1-foo": "bar", "pvbtest2-abc": "123"},
@@ -94,10 +94,10 @@ func TestGetVolumeBackupsForPod(t *testing.T) {
 		{
 			name: "no snapshot annotation, but with PVBs, some of which have snapshot IDs and some of which don't",
 			podVolumeBackups: []*velerov1api.PodVolumeBackup{
-				builder.ForPodVolumeBackup("velero", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-3").PodName("TestPod").Volume("pvbtest3-foo").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-4").PodName("TestPod").Volume("pvbtest4-abc").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-3").PodName("TestPod").Volume("pvbtest3-foo").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-4").PodName("TestPod").Volume("pvbtest4-abc").Result(),
 			},
 			podName:  "TestPod",
 			expected: map[string]string{"pvbtest1-foo": "bar", "pvbtest2-abc": "123"},
@@ -105,9 +105,9 @@ func TestGetVolumeBackupsForPod(t *testing.T) {
 		{
 			name: "has snapshot annotation, with suffix, and with PVBs from current pod and a PVB from another pod",
 			podVolumeBackups: []*velerov1api.PodVolumeBackup{
-				builder.ForPodVolumeBackup("velero", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
-				builder.ForPodVolumeBackup("velero", "pvb-3").PodName("TestAnotherPod").SnapshotID("xyz").Volume("pvbtest3-xyz").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-1").PodName("TestPod").SnapshotID("bar").Volume("pvbtest1-foo").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-2").PodName("TestPod").SnapshotID("123").Volume("pvbtest2-abc").Result(),
+				builder.ForPodVolumeBackup("openshift-migration", "pvb-3").PodName("TestAnotherPod").SnapshotID("xyz").Volume("pvbtest3-xyz").Result(),
 			},
 			podAnnotations: map[string]string{"x": "y", podAnnotationPrefix + "foo": "bar", podAnnotationPrefix + "abc": "123"},
 			podName:        "TestPod",
@@ -350,7 +350,7 @@ func TestTempCredentialsFile(t *testing.T) {
 		fs             = velerotest.NewFakeFileSystem()
 		secret         = &corev1api.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "velero",
+				Namespace: "openshift-migration",
 				Name:      CredentialsSecretName,
 			},
 			Data: map[string][]byte{
@@ -360,14 +360,14 @@ func TestTempCredentialsFile(t *testing.T) {
 	)
 
 	// secret not in lister: expect an error
-	fileName, err := TempCredentialsFile(secretLister, "velero", "default", fs)
+	fileName, err := TempCredentialsFile(secretLister, "openshift-migration", "default", fs)
 	assert.Error(t, err)
 
 	// now add secret to lister
 	require.NoError(t, secretInformer.GetStore().Add(secret))
 
 	// secret in lister: expect temp file to be created with password
-	fileName, err = TempCredentialsFile(secretLister, "velero", "default", fs)
+	fileName, err = TempCredentialsFile(secretLister, "openshift-migration", "default", fs)
 	require.NoError(t, err)
 
 	contents, err := fs.ReadFile(fileName)


### PR DESCRIPTION
*Do not merge*

This is required to make tests work as a result of
 https://github.com/fusor/velero/pull/43.

However, at this point I think it would be better to *not* merge
this and revert PR #43 and find another way to deal with the
namespace change, since this is a bunch of hard-coded changes to
maintain on top of upstream going forward.