### PR TITLE
Add support for private registry with custom port in restic-helper

### DIFF
--- a/changelogs/unreleased/1999-cognoz
+++ b/changelogs/unreleased/1999-cognoz
@@ -1,0 +1,1 @@
+add support for a private registry with a custom port in a restic-helper image

--- a/pkg/restore/restic_restore_action.go
+++ b/pkg/restore/restic_restore_action.go
@@ -156,20 +156,22 @@ func getImage(log logrus.FieldLogger, config *corev1.ConfigMap) string {
 
 	log = log.WithField("image", image)
 
-	parts := strings.Split(image, ":")
-	switch {
-	case len(parts) == 1:
+	parts := strings.Split(image, "/")
+
+	if len(parts) == 1 {
+		// Image supplied without registry part
+		log.Debugf("Plugin config contains image name without registry name. Return defaultImageBase")
+		return initContainerImage(defaultImageBase)
+	}
+
+	if !(strings.Contains(parts[len(parts)-1], ":")) {
 		// tag-less image name: add tag
 		log.Debugf("Plugin config contains image name without tag. Adding tag.")
 		return initContainerImage(image)
-	case len(parts) == 2:
+	} else {
 		// tagged image name
 		log.Debugf("Plugin config contains image name with tag")
 		return image
-	default:
-		// unrecognized
-		log.Warnf("Plugin config contains unparseable image name")
-		return initContainerImage(defaultImageBase)
 	}
 }
 

--- a/pkg/restore/restic_restore_action_test.go
+++ b/pkg/restore/restic_restore_action_test.go
@@ -69,8 +69,8 @@ func TestGetImage(t *testing.T) {
 			want:      fmt.Sprintf("%s:%s", defaultImageBase, buildinfo.Version),
 		},
 		{
-			name:      "config map with invalid data in 'image' key returns default image with buildinfo.Version as tag",
-			configMap: configMapWithData("image", "not:valid:image"),
+			name:      "config map without '/' in image name returns default image with buildinfo.Version as tag",
+			configMap: configMapWithData("image", "my-image"),
 			want:      fmt.Sprintf("%s:%s", defaultImageBase, buildinfo.Version),
 		},
 		{
@@ -79,9 +79,19 @@ func TestGetImage(t *testing.T) {
 			want:      fmt.Sprintf("%s:%s", "myregistry.io/my-image", buildinfo.Version),
 		},
 		{
+			name:      "config map with untagged image and custom registry port with ':' returns image with buildinfo.Version as tag",
+			configMap: configMapWithData("image", "myregistry.io:34567/my-image"),
+			want:      fmt.Sprintf("%s:%s", "myregistry.io:34567/my-image", buildinfo.Version),
+		},
+		{
 			name:      "config map with tagged image returns tagged image",
 			configMap: configMapWithData("image", "myregistry.io/my-image:my-tag"),
 			want:      "myregistry.io/my-image:my-tag",
+		},
+		{
+			name:      "config map with tagged image and custom registry port with ':' returns tagged image",
+			configMap: configMapWithData("image", "myregistry.io:34567/my-image:my-tag"),
+			want:      "myregistry.io:34567/my-image:my-tag",
 		},
 	}
 


### PR DESCRIPTION
Upstream cherry-pick of https://github.com/vmware-tanzu/velero/pull/1999

(corresponding to https://github.com/fusor/velero/pull/42 on release-1.0 branch)