### PR TITLE
Revert "fix namespace for our install location"

### DIFF
--- a/pkg/apis/velero/v1/constants.go
+++ b/pkg/apis/velero/v1/constants.go
@@ -19,7 +19,7 @@ package v1
 const (
 	// DefaultNamespace is the Kubernetes namespace that is used by default for
 	// the Velero server and API objects.
-	DefaultNamespace = "openshift-migration"
+	DefaultNamespace = "velero"
 
 	// ResourcesDir is a top-level directory expected in backups which contains sub-directories
 	// for each resource type in the backup.


### PR DESCRIPTION
This reverts commit 0dfdf8ccb3da70d5b2a41ad86a4d7c2ccd223e8c.
At one point this change was needed, but as of velero 1.2
it seems to be unnecessary.
