### PR TITLE
Check for nil LastMaintenanceTime in dueForMaintenance

### DIFF
--- a/pkg/controller/restic_repository_controller.go
+++ b/pkg/controller/restic_repository_controller.go
@@ -243,7 +243,7 @@ func (c *resticRepositoryController) runMaintenanceIfDue(req *v1.ResticRepositor
 }
 
 func dueForMaintenance(req *v1.ResticRepository, now time.Time) bool {
-	return req.Status.LastMaintenanceTime.Add(req.Spec.MaintenanceFrequency.Duration).Before(now)
+	return req.Status.LastMaintenanceTime == nil || req.Status.LastMaintenanceTime.Add(req.Spec.MaintenanceFrequency.Duration).Before(now)
 }
 
 func (c *resticRepositoryController) checkNotReadyRepo(req *v1.ResticRepository, log logrus.FieldLogger) error {


### PR DESCRIPTION
ResticRepository.dueForMaintenance causes a panic in the velero pod
("invalid memory address or nil pointer dereference") if
repository.Status.LastMaintenanceTime is nil. This fix returns 'true'
if it's nil, so the repository is due for maintenance if LastMaintenanceTime
is nil *or* the time elapsed since the last maintenance is greater than
repository.Spec.MaintenanceFrequency.Duration

This corresponds to upstream PR: https://github.com/vmware-tanzu/velero/pull/2200