### PR TITLE
add ps to hotfix container to help diagnose hangs

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -10,7 +10,7 @@ RUN mkdir /go/src/github.com/restic \
 && CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' ./cmd/restic
 
 FROM registry.access.redhat.com/ubi8-minimal
-RUN microdnf -y install nmap-ncat && microdnf clean all
+RUN microdnf -y install nmap-ncat procps-ng && microdnf clean all
 RUN microdnf -y update && microdnf clean all
 
 COPY --from=builder /go/src/github.com/vmware-tanzu/velero/velero velero

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -171,7 +171,9 @@ func NewCommand(f client.Factory) *cobra.Command {
 			logger.Infof("setting log-level to %s", strings.ToUpper(logLevel.String()))
 
 			logger.Infof("Starting Velero server %s (%s)", buildinfo.Version, buildinfo.FormattedGitSHA())
+			logger.Infof("Konveyor HotFix #2")
 			logger.Infof("Konveyor HotFix #1 - Bump restic repo timeout")
+			logger.Infof("Konveyor HotFix #2 - Add procpps-ng package to the container")
 			if len(features.All()) > 0 {
 				logger.Infof("%d feature flags enabled %s", len(features.All()), features.All())
 			} else {
@@ -279,12 +281,12 @@ func newServer(f client.Factory, config serverConfig, logger *logrus.Logger) (*s
 		discoveryClient:       veleroClient.Discovery(),
 		dynamicClient:         dynamicClient,
 		sharedInformerFactory: informers.NewSharedInformerFactoryWithOptions(veleroClient, 0, informers.WithNamespace(f.Namespace())),
-		ctx:            ctx,
-		cancelFunc:     cancelFunc,
-		logger:         logger,
-		logLevel:       logger.Level,
-		pluginRegistry: pluginRegistry,
-		config:         config,
+		ctx:                   ctx,
+		cancelFunc:            cancelFunc,
+		logger:                logger,
+		logLevel:              logger.Level,
+		pluginRegistry:        pluginRegistry,
+		config:                config,
 	}
 
 	return s, nil


### PR DESCRIPTION
We are getting stuck around here on at least some PVs:
https://github.com/vmware-tanzu/velero/blob/4d49b5971c167f2a275efe15d5ac7f287edf41f0/pkg/controller/pod_volume_backup_controller.go#L266-L287

Adding `ps` because we would like to:
* See if restic is running or not when we hang
* If it is running, duplicate the command-line flags it is running with to see if we can figure out why it is hanging.