### PR TITLE
bug 1967858 - bug introduced in 1.6 restore progress: fix CR restore

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -377,6 +377,10 @@ func getOrderedResources(resourcePriorities []string, backupResources map[string
 	return append(resourcePriorities, orderedBackupResources...)
 }
 
+type progressUpdate struct {
+	totalItems, itemsRestored int
+}
+
 func (ctx *restoreContext) execute() (Result, Result) {
 	warnings, errs := Result{}, Result{}
 
@@ -407,14 +411,6 @@ func (ctx *restoreContext) execute() (Result, Result) {
 				return warnings, errs
 			}
 		}
-	}
-
-	selectedResourceCollection, w, e := ctx.getOrderedResourceCollection(backupResources)
-	warnings.Merge(&w)
-	errs.Merge(&e)
-
-	type progressUpdate struct {
-		totalItems, itemsRestored int
 	}
 
 	update := make(chan progressUpdate)
@@ -458,92 +454,51 @@ func (ctx *restoreContext) execute() (Result, Result) {
 	// totalItems: previously discovered items, i: iteration counter.
 	totalItems, i, existingNamespaces := 0, 0, sets.NewString()
 
+	// First restore only CRDs
+	crdResourceCollection, processedResources, w, e := ctx.getOrderedResourceCollection(
+		backupResources,
+		make([]restoreableResource, 0),
+		sets.NewString(),
+		[]string{"customresourcedefinitions"},
+		false,
+	)
+	warnings.Merge(&w)
+	errs.Merge(&e)
+
+	for _, selectedResource := range crdResourceCollection {
+		totalItems += selectedResource.totalItems
+	}
+
+	for _, selectedResource := range crdResourceCollection {
+		var w, e Result
+		i, w, e = ctx.processSelectedResource(selectedResource, totalItems, i, existingNamespaces, update)
+		warnings.Merge(&w)
+		errs.Merge(&e)
+	}
+
+	// Restore everything else
+	selectedResourceCollection, _, w, e := ctx.getOrderedResourceCollection(
+		backupResources,
+		crdResourceCollection,
+		processedResources,
+		ctx.resourcePriorities,
+		true,
+	)
+	warnings.Merge(&w)
+	errs.Merge(&e)
+
+	// reset i and totalItems after processing full resource list
+	i = 0
+	totalItems = 0
 	for _, selectedResource := range selectedResourceCollection {
 		totalItems += selectedResource.totalItems
 	}
 
 	for _, selectedResource := range selectedResourceCollection {
-		groupResource := schema.ParseGroupResource(selectedResource.resource)
-
-		for namespace, selectedItems := range selectedResource.selectedItemsByNamespace {
-			for _, selectedItem := range selectedItems {
-				// If we don't know whether this namespace exists yet, attempt to create
-				// it in order to ensure it exists. Try to get it from the backup tarball
-				// (in order to get any backed-up metadata), but if we don't find it there,
-				// create a blank one.
-				if namespace != "" && !existingNamespaces.Has(selectedItem.targetNamespace) {
-					logger := ctx.log.WithField("namespace", namespace)
-
-					ns := getNamespace(
-						logger,
-						archive.GetItemFilePath(ctx.restoreDir, "namespaces", "", namespace),
-						selectedItem.targetNamespace,
-					)
-					_, nsCreated, err := kube.EnsureNamespaceExistsAndIsReady(
-						ns,
-						ctx.namespaceClient,
-						ctx.resourceTerminatingTimeout,
-					)
-					if err != nil {
-						errs.AddVeleroError(err)
-						continue
-					}
-
-					// Add the newly created namespace to the list of restored items.
-					if nsCreated {
-						itemKey := velero.ResourceIdentifier{
-							GroupResource: kuberesource.Namespaces,
-							Namespace:     ns.Namespace,
-							Name:          ns.Name,
-						}
-						ctx.restoredItems[itemKey] = struct{}{}
-					}
-
-					// Keep track of namespaces that we know exist so we don't
-					// have to try to create them multiple times.
-					existingNamespaces.Insert(selectedItem.targetNamespace)
-				}
-
-				obj, err := archive.Unmarshal(ctx.fileSystem, selectedItem.path)
-				if err != nil {
-					errs.Add(
-						selectedItem.targetNamespace,
-						fmt.Errorf(
-							"error decoding %q: %v",
-							strings.Replace(selectedItem.path, ctx.restoreDir+"/", "", -1),
-							err,
-						),
-					)
-					continue
-				}
-
-				w, e := ctx.restoreItem(obj, groupResource, selectedItem.targetNamespace)
-				warnings.Merge(&w)
-				errs.Merge(&e)
-				i++
-
-				// totalItems keeps the count of items previously known. There
-				// may be additional items restored by plugins. We want to include
-				// the additional items by looking at restoredItems at the same
-				// time, we don't want previously known items counted twice as
-				// they are present in both restoredItems and totalItems.
-				actualTotalItems := len(ctx.restoredItems) + (totalItems - i)
-				update <- progressUpdate{
-					totalItems:    actualTotalItems,
-					itemsRestored: len(ctx.restoredItems),
-				}
-			}
-		}
-
-		// If we just restored custom resource definitions (CRDs), refresh
-		// discovery because the restored CRDs may have created new APIs that
-		// didn't previously exist in the cluster, and we want to be able to
-		// resolve & restore instances of them in subsequent loop iterations.
-		if groupResource == kuberesource.CustomResourceDefinitions {
-			if err := ctx.discoveryHelper.Refresh(); err != nil {
-				warnings.Add("", errors.Wrap(err, "refresh discovery after restoring CRDs"))
-			}
-		}
+		var w, e Result
+		i, w, e = ctx.processSelectedResource(selectedResource, totalItems, i, existingNamespaces, update)
+		warnings.Merge(&w)
+		errs.Merge(&e)
 	}
 
 	// Close the progress update channel.
@@ -603,6 +558,104 @@ func (ctx *restoreContext) execute() (Result, Result) {
 	ctx.log.Info("Done waiting for all post-restore exec hooks to complete")
 
 	return warnings, errs
+}
+
+func (ctx *restoreContext) processSelectedResource(
+	selectedResource restoreableResource,
+	totalItems int,
+	i int,
+	existingNamespaces sets.String,
+	update chan progressUpdate,
+) (int, Result, Result) {
+	warnings, errs := Result{}, Result{}
+	groupResource := schema.ParseGroupResource(selectedResource.resource)
+
+	for namespace, selectedItems := range selectedResource.selectedItemsByNamespace {
+		for _, selectedItem := range selectedItems {
+			// If we don't know whether this namespace exists yet, attempt to create
+			// it in order to ensure it exists. Try to get it from the backup tarball
+			// (in order to get any backed-up metadata), but if we don't find it there,
+			// create a blank one.
+			if namespace != "" && !existingNamespaces.Has(selectedItem.targetNamespace) {
+				logger := ctx.log.WithField("namespace", namespace)
+
+				ns := getNamespace(
+					logger,
+					archive.GetItemFilePath(ctx.restoreDir, "namespaces", "", namespace),
+					selectedItem.targetNamespace,
+				)
+				_, nsCreated, err := kube.EnsureNamespaceExistsAndIsReady(
+					ns,
+					ctx.namespaceClient,
+					ctx.resourceTerminatingTimeout,
+				)
+				if err != nil {
+					errs.AddVeleroError(err)
+					continue
+				}
+
+				// Add the newly created namespace to the list of restored items.
+				if nsCreated {
+					itemKey := velero.ResourceIdentifier{
+						GroupResource: kuberesource.Namespaces,
+						Namespace:     ns.Namespace,
+						Name:          ns.Name,
+					}
+					ctx.restoredItems[itemKey] = struct{}{}
+				}
+
+				// Keep track of namespaces that we know exist so we don't
+				// have to try to create them multiple times.
+				existingNamespaces.Insert(selectedItem.targetNamespace)
+			}
+
+			obj, err := archive.Unmarshal(ctx.fileSystem, selectedItem.path)
+			if err != nil {
+				errs.Add(
+					selectedItem.targetNamespace,
+					fmt.Errorf(
+						"error decoding %q: %v",
+						strings.Replace(selectedItem.path, ctx.restoreDir+"/", "", -1),
+						err,
+					),
+				)
+				continue
+			}
+
+			w, e := ctx.restoreItem(obj, groupResource, selectedItem.targetNamespace)
+			warnings.Merge(&w)
+			errs.Merge(&e)
+			i++
+
+			// totalItems keeps the count of items previously known. There
+			// may be additional items restored by plugins. We want to include
+			// the additional items by looking at restoredItems at the same
+			// time, we don't want previously known items counted twice as
+			// they are present in both restoredItems and totalItems.
+			actualTotalItems := len(ctx.restoredItems) + (totalItems - i)
+			update <- progressUpdate{
+				totalItems:    actualTotalItems,
+				itemsRestored: len(ctx.restoredItems),
+			}
+			ctx.log.WithFields(map[string]interface{}{
+				"progress":  "",
+				"resource":  groupResource.String(),
+				"namespace": selectedItem.targetNamespace,
+				"name":      selectedItem.name,
+			}).Infof("Restored %d items out of an estimated total of %d (estimate will change throughout the restore)", len(ctx.restoredItems), actualTotalItems)
+		}
+	}
+
+	// If we just restored custom resource definitions (CRDs), refresh
+	// discovery because the restored CRDs may have created new APIs that
+	// didn't previously exist in the cluster, and we want to be able to
+	// resolve & restore instances of them in subsequent loop iterations.
+	if groupResource == kuberesource.CustomResourceDefinitions {
+		if err := ctx.discoveryHelper.Refresh(); err != nil {
+			warnings.Add("", errors.Wrap(err, "refresh discovery after restoring CRDs"))
+		}
+	}
+	return i, warnings, errs
 }
 
 // getNamespace returns a namespace API object that we should attempt to
@@ -1590,10 +1643,14 @@ type restoreableItem struct {
 // identifiers, applies resource include/exclude criteria, and Kubernetes
 // selectors to make a list of resources to be actually restored preserving the
 // original order.
-func (ctx *restoreContext) getOrderedResourceCollection(backupResources map[string]*archive.ResourceItems) ([]restoreableResource, Result, Result) {
+func (ctx *restoreContext) getOrderedResourceCollection(
+	backupResources map[string]*archive.ResourceItems,
+	restoreResourceCollection []restoreableResource,
+	processedResources sets.String,
+	resourcePriorities []string,
+	includeAllResources bool,
+) ([]restoreableResource, sets.String, Result, Result) {
 	var warnings, errs Result
-	processedResources := sets.NewString()
-	restoreResourceCollection := make([]restoreableResource, 0)
 	// Iterate through an ordered list of resources to restore, checking each
 	// one to see if it should be restored. Note that resources *may* be in this
 	// list twice, i.e. once due to being a prioritized resource, and once due
@@ -1608,7 +1665,13 @@ func (ctx *restoreContext) getOrderedResourceCollection(backupResources map[stri
 	// Since we keep track of the fully-resolved group-resources that we *have*
 	// restored, we won't try to restore a resource twice even if it's in the
 	// ordered list twice.
-	for _, resource := range getOrderedResources(ctx.resourcePriorities, backupResources) {
+	var resourceList []string
+	if includeAllResources {
+		resourceList = getOrderedResources(resourcePriorities, backupResources)
+	} else {
+		resourceList = resourcePriorities
+	}
+	for _, resource := range resourceList {
 		// try to resolve the resource via discovery to a complete group/version/resource
 		gvr, _, err := ctx.discoveryHelper.ResourceFor(schema.ParseGroupResource(resource).WithVersion(""))
 		if err != nil {
@@ -1681,7 +1744,7 @@ func (ctx *restoreContext) getOrderedResourceCollection(backupResources map[stri
 		// record that we've restored the resource
 		processedResources.Insert(groupResource.String())
 	}
-	return restoreResourceCollection, warnings, errs
+	return restoreResourceCollection, processedResources, warnings, errs
 }
 
 // getSelectedRestoreableItems applies Kubernetes selectors on individual items


### PR DESCRIPTION
restore progress introduced a bug with CR restore, since velero now iterates over the items to restore *before* restoring, so when it attempted to validate CRs in the backup, they'd fail validation if they relied on a CRD to be restored from the same backup. This change restores CRDs first and then iterates over everything else to validate and  populate restore progress metadata.