### PR TITLE
Bug 2000979: Empty "ClusterIPs"  when "ClusterIP" isn't "None" (#4101)

### DIFF
--- a/changelogs/unreleased/4101-ywk253100
+++ b/changelogs/unreleased/4101-ywk253100
@@ -1,0 +1,1 @@
+Empty the "ClusterIPs" along with "ClusterIP" when "ClusterIP" isn't "None"

--- a/pkg/restore/service_action.go
+++ b/pkg/restore/service_action.go
@@ -54,6 +54,7 @@ func (a *ServiceAction) Execute(input *velero.RestoreItemActionExecuteInput) (*v
 
 	if service.Spec.ClusterIP != "None" {
 		service.Spec.ClusterIP = ""
+		service.Spec.ClusterIPs = nil
 	}
 
 	/* Do not delete NodePorts if restore triggered with "--preserve-nodeports" flag */

--- a/pkg/restore/service_action_test.go
+++ b/pkg/restore/service_action_test.go
@@ -58,13 +58,14 @@ func TestServiceActionExecute(t *testing.T) {
 		expectedRes corev1api.Service
 	}{
 		{
-			name: "clusterIP (only) should be deleted from spec",
+			name: "clusterIP/clusterIPs should be deleted from spec",
 			obj: corev1api.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "svc-1",
 				},
 				Spec: corev1api.ServiceSpec{
 					ClusterIP:      "should-be-removed",
+					ClusterIPs:     []string{"should-be-removed"},
 					LoadBalancerIP: "should-be-kept",
 				},
 			},


### PR DESCRIPTION
(cherry-pick from upstream)
More details please refer to #4098

Fixes #4098

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>

