### PR TITLE
Use numeric user for velero-restic-restore-helper

### DIFF
--- a/Dockerfile-velero-restic-restore-helper.ubi
+++ b/Dockerfile-velero-restic-restore-helper.ubi
@@ -9,6 +9,6 @@ RUN microdnf -y update && microdnf clean all
 
 COPY --from=builder /opt/app-root/src/velero-restic-restore-helper velero-restic-restore-helper
 
-USER nobody:nobody
+USER 65534:65534
 
 ENTRYPOINT [ "/velero-restic-restore-helper" ]


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Us a numeric user instead of `nobody` for the velero-restic-restore-helper.

# Does your change fix a particular issue?
This PR fixes #122.

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
