### PR TITLE
Bug 2015548: fix paging items in to use list options passed by the paging function

### DIFF
--- a/pkg/backup/item_collector.go
+++ b/pkg/backup/item_collector.go
@@ -302,7 +302,8 @@ func (r *itemCollector) getResourceItems(log logrus.FieldLogger, gv schema.Group
 			// If limit is positive, use a pager to split list over multiple requests
 			// Use Velero's dynamic list function instead of the default
 			listFunc := pager.SimplePageFunc(func(opts metav1.ListOptions) (runtime.Object, error) {
-				list, err := resourceClient.List(listOptions)
+				opts.LabelSelector = labelSelector
+				list, err := resourceClient.List(opts)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
The client-go pager sets the Limit options for the list call
to paginate the request[1]. This PR fixes the paging function
to use the options passed by the pager instead of shadowed options
This is required for the pagination to work correctly.

1. https://github.com/kubernetes/kubernetes/blob/3f40906dd8a54fb91650553a6457496181f591bc/staging/src/k8s.io/client-go/tools/pager/pager.go#L219

Signed-off-by: Alay Patel <alay1431@gmail.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required`.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
