### PR TITLE
Use numeric user for velero-restic-restore-helper

### DIFF
--- a/Dockerfile-velero-restic-restore-helper.ubi
+++ b/Dockerfile-velero-restic-restore-helper.ubi
@@ -9,6 +9,6 @@ RUN microdnf -y update && microdnf clean all
 
 COPY --from=builder /opt/app-root/src/velero-restic-restore-helper velero-restic-restore-helper
 
-USER nobody:nobody
+USER 65534:65534
 
 ENTRYPOINT [ "/velero-restic-restore-helper" ]


### PR DESCRIPTION
    Use numeric user for velero-restic-restore-helper
    
    Signed-off-by: Norwin Schnyder <norwin.schnyder+github@gmail.com>

Cherry-picked from cabd8e940f994f58af6be17066ac0b29ec71df91
