### PR TITLE
Use builder:v1.16 image in Dockerfile.ubi

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,5 +1,4 @@
-# TODO! Find a real ubi8 image for golang 1.16
-FROM quay.io/app-sre/boilerplate:image-v2.1.0 AS builder
+FROM quay.io/konveyor/builder:v1.16 as builder
 ENV GOPATH=$APP_ROOT
 COPY . /go/src/github.com/vmware-tanzu/velero
 WORKDIR /go/src/github.com/vmware-tanzu/velero


### PR DESCRIPTION
The `boilerplate:image-v2.1.0` currently used in `Dockerfile.ubi` is not compatible on `s390x` arch.

This PR attempts to use the multi-arch `builder:v1.16` [image](https://quay.io/repository/konveyor/builder?tab=tags) available on `quay.io` which works on `s390x`.  I was also able to successfully build `velero` image on `x86` arch using `builder:v1.16` image.

Thanks.