### PR TITLE
Added support for restic --verify flag (konveyor-1.7 cherry-pick)

### DIFF
--- a/pkg/controller/pod_volume_restore_controller.go
+++ b/pkg/controller/pod_volume_restore_controller.go
@@ -306,7 +306,7 @@ func (c *podVolumeRestoreController) processRestore(req *velerov1api.PodVolumeRe
 	}
 
 	// execute the restore process
-	if err := c.restorePodVolume(req, volumeDir, log); err != nil {
+	if err := c.restorePodVolume(req, volumeDir, log, restic.GetVolumesToVerifyIncludes(pod, req.Spec.Volume)); err != nil {
 		log.WithError(err).Error("Error restoring volume")
 		return c.failRestore(req, errors.Wrap(err, "error restoring volume").Error(), log)
 	}
@@ -325,7 +325,7 @@ func (c *podVolumeRestoreController) processRestore(req *velerov1api.PodVolumeRe
 	return nil
 }
 
-func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolumeRestore, volumeDir string, log logrus.FieldLogger) error {
+func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolumeRestore, volumeDir string, log logrus.FieldLogger, verify bool) error {
 	// Get the full path of the new volume's directory as mounted in the daemonset pod, which
 	// will look like: /host_pods/<new-pod-uid>/volumes/<volume-plugin-name>/<volume-dir>
 	volumePath, err := singlePathMatch(fmt.Sprintf("/host_pods/%s/volumes/*/%s", string(req.Spec.Pod.UID), volumeDir))
@@ -346,6 +346,7 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 		credsFile,
 		req.Spec.SnapshotID,
 		volumePath,
+		verify,
 	)
 
 	backupLocation := &velerov1api.BackupStorageLocation{}
@@ -392,10 +393,15 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 
 	var stdout, stderr string
 
-	if stdout, stderr, err = restic.RunRestore(resticCmd, log, c.updateRestoreProgressFunc(req, log)); err != nil {
+	stdout, stderr, err = restic.RunRestore(resticCmd, log, c.updateRestoreProgressFunc(req, log))
+	pvrErr := c.processRestoreErrors(req, stdout, stderr, verify)
+	if pvrErr != nil {
+		log.WithError(pvrErr).Error("error updating PodVolumeRestore errors")
+	}
+	if err != nil {
 		return errors.Wrapf(err, "error running restic restore, cmd=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
 	}
-	log.Debugf("Ran command=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
+	log.Infof("Ran command=%s, stdout=%s, stderr=%s", resticCmd.String(), stdout, stderr)
 
 	// Remove the .velero directory from the restored volume (it may contain done files from previous restores
 	// of this volume, which we don't want to carry over). If this fails for any reason, log and continue, since
@@ -429,6 +435,35 @@ func (c *podVolumeRestoreController) restorePodVolume(req *velerov1api.PodVolume
 	return nil
 }
 
+func (c *podVolumeRestoreController) processRestoreErrors(req *velerov1api.PodVolumeRestore, stdout, stderr string, verify bool) error {
+	nErrors := 0
+	nVerifyErrors := 0
+	for _, str := range strings.Split(stdout, "\n") {
+		var i int
+		_, err := fmt.Sscanf(str, "There were %d errors", &i)
+		if err == nil {
+			nErrors = i
+		}
+	}
+	if verify {
+		for _, str := range strings.Split(stderr, "\n") {
+			if strings.Contains(str, "Unexpected contents starting at offset") || strings.Contains(str, "Invalid file size: expected") {
+				nVerifyErrors++
+			}
+		}
+	}
+	if _, err := c.patchPodVolumeRestore(req, func(r *velerov1api.PodVolumeRestore) {
+		if r.Annotations == nil {
+			r.Annotations = make(map[string]string)
+		}
+		r.Annotations[restic.PVRErrorsAnnotation] = strconv.FormatInt(int64(nErrors), 10)
+		r.Annotations[restic.PVRVerifyErrorsAnnotation] = strconv.FormatInt(int64(nVerifyErrors), 10)
+		r.Annotations[restic.PVRResticPodAnnotation] = os.Getenv("POD_NAME")
+	}); err != nil {
+		return err
+	}
+	return nil
+}
 func (c *podVolumeRestoreController) patchPodVolumeRestore(req *velerov1api.PodVolumeRestore, mutate func(*velerov1api.PodVolumeRestore)) (*velerov1api.PodVolumeRestore, error) {
 	// Record original json
 	oldData, err := json.Marshal(req)

--- a/pkg/restic/command_factory.go
+++ b/pkg/restic/command_factory.go
@@ -47,14 +47,20 @@ func backupTagFlags(tags map[string]string) []string {
 }
 
 // RestoreCommand returns a Command for running a restic restore.
-func RestoreCommand(repoIdentifier, passwordFile, snapshotID, target string) *Command {
+func RestoreCommand(repoIdentifier, passwordFile, snapshotID, target string, verify bool) *Command {
+	extraFlags := []string{"--target=.", "--delete"}
+	if verify {
+		extraFlags = append(extraFlags, "--verify")
+	} else {
+		extraFlags = append(extraFlags, "--skip-unchanged")
+	}
 	return &Command{
 		Command:        "restore",
 		RepoIdentifier: repoIdentifier,
 		PasswordFile:   passwordFile,
 		Dir:            target,
 		Args:           []string{snapshotID},
-		ExtraFlags:     []string{"--target=.", "--skip-unchanged", "--delete"},
+		ExtraFlags:     extraFlags,
 	}
 }
 

--- a/pkg/restic/command_factory_test.go
+++ b/pkg/restic/command_factory_test.go
@@ -39,14 +39,25 @@ func TestBackupCommand(t *testing.T) {
 }
 
 func TestRestoreCommand(t *testing.T) {
-	c := RestoreCommand("repo-id", "password-file", "snapshot-id", "target")
+	c := RestoreCommand("repo-id", "password-file", "snapshot-id", "target", false)
 
 	assert.Equal(t, "restore", c.Command)
 	assert.Equal(t, "repo-id", c.RepoIdentifier)
 	assert.Equal(t, "password-file", c.PasswordFile)
 	assert.Equal(t, "target", c.Dir)
 	assert.Equal(t, []string{"snapshot-id"}, c.Args)
-	assert.Equal(t, []string{"--target=.", "--skip-unchanged", "--delete"}, c.ExtraFlags)
+	assert.Equal(t, []string{"--target=.", "--delete", "--skip-unchanged"}, c.ExtraFlags)
+}
+
+func TestRestoreVerifyCommand(t *testing.T) {
+	c := RestoreCommand("repo-id", "password-file", "snapshot-id", "target", true)
+
+	assert.Equal(t, "restore", c.Command)
+	assert.Equal(t, "repo-id", c.RepoIdentifier)
+	assert.Equal(t, "password-file", c.PasswordFile)
+	assert.Equal(t, "target", c.Dir)
+	assert.Equal(t, []string{"snapshot-id"}, c.Args)
+	assert.Equal(t, []string{"--target=.", "--delete", "--verify"}, c.ExtraFlags)
 }
 
 func TestGetSnapshotCommand(t *testing.T) {

--- a/pkg/restic/common.go
+++ b/pkg/restic/common.go
@@ -66,6 +66,38 @@ const (
 	// the BSL is using its own credentials, rather than those in the environment
 	credentialsFileKey = "credentialsFile"
 
+	// VolumesToVerifyAnnotation is the annotation on a pod whose mounted volumes
+	// need to be verified after backing up with restic.
+	VolumesToVerifyAnnotation = "backup.velero.io/verify-volumes"
+
+	// PVRErrorsAnnotation is the annotation on a PVR indicating the number of
+	// errors on running restic restore.
+	PVRErrorsAnnotation = "velero.io/pvr-errors"
+
+	// PVRVerifyErrorsAnnotation is the annotation on a PVR indicating the number of
+	// verify errors on running restic restore.
+	PVRVerifyErrorsAnnotation = "velero.io/pvr-verify-errors"
+
+	// PVRPodNameAnnotation is the annotation on a PVR indicating the name of the
+	// restic pod that ran the restic restore (for looking up error messages)
+	PVRResticPodAnnotation = "velero.io/pvr-restic-pod"
+
+	// RestorePVRErrorsAnnotation is the annotation on a restore providing a list of
+	// PVRs with errors on running restic restore.
+	RestorePVRErrorsAnnotation = "velero.io/restore-pvr-errors"
+
+	// RestorePVRVerifyErrorsAnnotation is the annotation on a restore providing a list of
+	// PVRs with verify errors on running restic restore.
+	RestorePVRVerifyErrorsAnnotation = "velero.io/restore-pvr-verify-errors"
+
+	// RestorePVRErrorCountAnnotation is the annotation on a restore specifying how many
+	// PVRs had errors on running restic restore.
+	RestorePVRErrorCountAnnotation = "velero.io/restore-pvr-error-count"
+
+	// RestorePVRVerifyErrorCountAnnotation is the annotation on a restore specifying how many
+	// PVRs had verify errors on running restic restore.
+	RestorePVRVerifyErrorCountAnnotation = "velero.io/restore-pvr-verify-error-count"
+
 	// Deprecated.
 	//
 	// TODO(2.0): remove
@@ -176,6 +208,27 @@ func getVolumesToExclude(obj metav1.Object) []string {
 func contains(list []string, k string) bool {
 	for _, i := range list {
 		if i == k {
+			return true
+		}
+	}
+	return false
+}
+
+// GetVolumesToVerifyIncludes returns true if the passed-in
+// volume name is included in the VolumesToVerifyAnnotation
+func GetVolumesToVerifyIncludes(obj metav1.Object, volName string) bool {
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	volumesValue := annotations[VolumesToVerifyAnnotation]
+	if volumesValue == "" {
+		return false
+	}
+
+	for _, vol := range strings.Split(volumesValue, ",") {
+		if vol == volName {
 			return true
 		}
 	}


### PR DESCRIPTION
Added support for restic volume checksum verification.
This adds another pod annotation ('backup.velero.io/verify-volumes')
which is used to identify which volumes on the pod should get the
'--verify' flag passed to restic when restoring.

Stdout and stderr are logged to the restic pod logs. The PodVolumeRestore
CRD has three new status fields: Errors, VerifyErrors, and ResticPod,
which contain the number of total errors reported, the number of verify
errors reported, and the name of the restic pod that ran the restore
(to allow for the user to look in the pod logs for more detailed output).

The Restore CRD has two new Status fields: PodVolumeRestoreErrors
and PodVolumeRestoreVerifyErrors, which contain a slice of ObjectReferences
listing which PodVolumeRestores contained errors or verify errors.

There is not yet support built into restore describe to see the restore fields
via the velero client. Also, the restic daemonset will need to have an env
variable set for POD_NAME.

(cherry picked from commit da2df66ad156ccd3c86dfb885634d744abc1b980)
(cherry picked from commit 5a05c6be5711fdcc93cbba7c53fdb3ece531cdde)
Signed-off-by: Scott Seago <sseago@redhat.com>

Refactored restic verify to use output annotations rather than (#146)

adding new status fields. This removes the CRD changes from upstream.

making sure pvr errors are getting reported correctly

