### PR TITLE
continue instead of return if matching plugin fails LabelSelector match

### DIFF
--- a/pkg/restore/restore.go
+++ b/pkg/restore/restore.go
@@ -1153,7 +1153,7 @@ func (ctx *restoreContext) restoreItem(obj *unstructured.Unstructured, groupReso
 
 	for _, action := range ctx.getApplicableActions(groupResource, namespace) {
 		if !action.selector.Matches(labels.Set(obj.GetLabels())) {
-			return warnings, errs
+			continue
 		}
 
 		ctx.log.Infof("Executing item action for %v", &groupResource)


### PR DESCRIPTION
When iterating over RestoreItemActions that match based on namespace and resource type, if an included LabelSelector is not a match, the current velero code has a bug -- it returns rather than continues to the next plugin. This means that if such a plugin exists, the resource will be discarded before restore without any logs indicating that this has happened.

The plugin that is triggering this bug is the Kubevirt pod restore plugin, which matches pods with kubevirt labels. Any pod needing restore without that label (such as a pod with attached PVC for restic restore) will be discarded as well. Replacing that `return` statement with `continue` resolves the problem.

Signed-off-by: Scott Seago <sseago@redhat.com>

