### PR TITLE
OADP-645:Clean temp VSClass for data mover restore 

### DIFF
--- a/pkg/controller/backup_controller.go
+++ b/pkg/controller/backup_controller.go
@@ -22,12 +22,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/vmware-tanzu/velero/pkg/datamover"
 	"io"
 	"io/ioutil"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/vmware-tanzu/velero/pkg/datamover"
 
 	"github.com/apex/log"
 	jsonpatch "github.com/evanphx/json-patch"
@@ -656,6 +657,12 @@ func (c *backupController) runBackup(backup *pkgbackup.Request) error {
 		//DataMover case
 		if datamover.DataMoverCase() {
 			err = datamover.WaitForDataMoverBackupToComplete(backup.Name)
+			if err != nil {
+				backupLog.Error(err)
+			}
+
+			// delete temp VSClass created for data mover restore
+			err := datamover.DeleteTempVSClass(backup.Name, c.volumeSnapshotClassLister, c.volumeSnapshotClient)
 			if err != nil {
 				backupLog.Error(err)
 			}

--- a/pkg/datamover/datamover.go
+++ b/pkg/datamover/datamover.go
@@ -3,17 +3,21 @@ package datamover
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"time"
+
 	"github.com/apex/log"
 	snapmoverv1alpha1 "github.com/konveyor/volume-snapshot-mover/api/v1alpha1"
+	snapshotterClientSet "github.com/kubernetes-csi/external-snapshotter/client/v4/clientset/versioned"
+	snapshotv1listers "github.com/kubernetes-csi/external-snapshotter/client/v4/listers/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
 	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"strconv"
-	"time"
 )
 
 const (
@@ -114,6 +118,22 @@ func WaitForDataMoverBackupToComplete(backupName string) error {
 			log.Errorf("failed to wait for VolumeSnapshotBackups to be completed: %s", err.Error())
 			return err
 		}
+	}
+	return nil
+}
+
+func DeleteTempVSClass(backupName string, tempVS snapshotv1listers.VolumeSnapshotClassLister, client *snapshotterClientSet.Clientset) error {
+
+	tempVSClass, err := tempVS.Get(fmt.Sprintf("%s-snapclass", backupName))
+	if err != nil {
+		log.Errorf("failed to get temp vsClass %v", tempVSClass.Name)
+		return err
+	}
+
+	err = client.SnapshotV1().VolumeSnapshotClasses().Delete(context.TODO(), tempVSClass.Name, metav1.DeleteOptions{})
+	if err != nil {
+		log.Errorf("failed to delete temp vsClass %v", tempVSClass.Name)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Deletes temp VSClass used for data mover restore performance improvements.

image: `quay.io/emcmulla/velero:perf`