### PR TITLE
Makefile.prow don't expand KUBEBUILDER_ASSETS until after envtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ jobs:
   - script: make verify
   - script: make all
   - script: make test
+  - script: make -f Makefile.prow ci

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -24,9 +24,8 @@ test: hack-docker
 hack-docker: envtest
 
 GOPATH:=$(shell go env GOPATH)
-KUBEBUILDER_ASSETS:=$(shell $(GOPATH)/bin/setup-envtest use -p path)
 #  if KUBEBUILDER_ASSETS contains space, escape it
-KUBEBUILDER_ASSETS:=$(shell echo $(KUBEBUILDER_ASSETS) | sed 's/ /\\ /g')
+KUBEBUILDER_ASSETS=$(shell echo $(shell $(GOPATH)/bin/setup-envtest use -p path) | sed 's/ /\\ /g')
 .PHONY: envtest
 envtest: $(GOPATH)/bin/setup-envtest
 	$(GOPATH)/bin/setup-envtest use -p path


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
