### PR TITLE
Makefile.prow `GOFLAGS=` when `go install`

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,4 +1,4 @@
-GOFLAGS="-mod=mod"
+GOFLAGS=-mod=mod
 # emulate as close as possible upstream ci target
 # upstream ci target: verify-modules verify all test
 # we skip verify for now
@@ -16,7 +16,7 @@ all:
 .PHONY: test
 # our test is modified to avoid docker usage
 test: hack-docker
-	@echo Using KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)
+	@echo Testing with KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) GOFLAGS=$(GOFLAGS) hack/test.sh
 
 .PHONY: hack-docker
@@ -31,4 +31,6 @@ envtest: $(GOPATH)/bin/setup-envtest
 	$(GOPATH)/bin/setup-envtest use -p path
 
 $(GOPATH)/bin/setup-envtest:
-	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@echo Installing envtest tools
+	GOFLAGS= go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	@echo Installed envtest tools


### PR DESCRIPTION
Prow [complaining](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/37289/rehearse-37289-pull-ci-openshift-velero-oadp-1.0-unit-test/1636089647241105408#1:build-log.txt%3A177) during `go install` only.
```
go: parsing $GOFLAGS: non-flag "\"-mod=mod\""
```

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
