### PR TITLE
Code-gen no longer required on verify

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -22,7 +22,7 @@ ci:
 	make -f $(MAKEFILE) verify all test
 
 .PHONY: verify
-verify: goimports code-generator controller-gen kubectl
+verify: goimports controller-gen kubectl #code-generator
 # add PROWBIN to PATH
 	@echo Verifying with PATH=$(PROWBIN):$(PATH)
 # Per


### PR DESCRIPTION
due to https://github.com/vmware-tanzu/velero/pull/6039

blocks https://github.com/openshift/release/pull/38076

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
