### PR TITLE
oadp-1.2: Update Makefile.prow to velero-restore-helper

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -39,7 +39,7 @@ verify: goimports controller-gen kubectl #code-generator
 .PHONY: all
 all:
 	GOFLAGS=$(GOFLAGS) make local
-	GOFLAGS=$(GOFLAGS) BIN=velero-restic-restore-helper make local
+	GOFLAGS=$(GOFLAGS) BIN=velero-restore-helper make local
 
 .PHONY: test
 # our test is modified to avoid docker usage


### PR DESCRIPTION
Blocks https://github.com/openshift/release/pull/38076
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
