### PR TITLE
OADP-2409 Restrict to velero namespace in node-agent cache

### DIFF
--- a/changelogs/unreleased/6528-Lyndon-Li
+++ b/changelogs/unreleased/6528-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #6519. Restrict the client manager of node-agent server to include only Velero resources from the server's namespace, otherwise, the controllers will try to reconcile CRs from all the installed Velero namespaces.

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -132,6 +132,12 @@ func newNodeAgentServer(logger logrus.FieldLogger, factory client.Factory, metri
 			&v1.Pod{}: {
 				Field: fields.Set{"spec.nodeName": nodeName}.AsSelector(),
 			},
+			&velerov1api.PodVolumeBackup{}: {
+				Field: fields.Set{"metadata.namespace": factory.Namespace()}.AsSelector(),
+			},
+			&velerov1api.PodVolumeRestore{}: {
+				Field: fields.Set{"metadata.namespace": factory.Namespace()}.AsSelector(),
+			},
 		},
 	}
 	mgr, err := ctrl.NewManager(clientConfig, ctrl.Options{


### PR DESCRIPTION
Cherrypick from upstream release-1.11 branch.

Restrict to velero namespace in node-agent cache so that node agent only picks up PVR/PVB for the current velero namespace, otherwise multiple Velero installs in the same cluster will be looking at the wrong CRs.