### PR TITLE
oadp-1.2: OADP-2530: Handle 1.27 k8s job label changes

### DIFF
--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -285,3 +285,11 @@ func (h *helper) ServerVersion() *version.Info {
 	defer h.lock.RUnlock()
 	return h.serverVersion
 }
+
+func ServerVersion(logger logrus.FieldLogger) (*version.Info, error) {
+	discoveryHelper, err := NewHelper(&discovery.DiscoveryClient{}, logger)
+	if err != nil {
+		return nil, err
+	}
+	return discoveryHelper.ServerVersion(), nil
+}

--- a/pkg/discovery/helper.go
+++ b/pkg/discovery/helper.go
@@ -285,11 +285,3 @@ func (h *helper) ServerVersion() *version.Info {
 	defer h.lock.RUnlock()
 	return h.serverVersion
 }
-
-func ServerVersion(logger logrus.FieldLogger) (*version.Info, error) {
-	discoveryHelper, err := NewHelper(&discovery.DiscoveryClient{}, logger)
-	if err != nil {
-		return nil, err
-	}
-	return discoveryHelper.ServerVersion(), nil
-}


### PR DESCRIPTION
per  https://github.com/kubernetes/kubernetes/blob/0e86fa5115cb79a04bdb949d135e35a31ce806f2/CHANGELOG/CHANGELOG-1.27.md?plain=1#L1768

Upstream PR: https://github.com/vmware-tanzu/velero/pull/6712 https://github.com/vmware-tanzu/velero/pull/6713

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Note Fixes:
Note: https://github.com/vmware-tanzu/velero/issues/6711

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
