### PR TITLE
Update OWNERS: remove '@' char

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,22 +3,22 @@
 
 # List of usernames who may use /lgtm
 reviewers:
-- @Lyndon-Li
-- @anshulahuja98
-- @blackpiglet
-- @qiuming-best
-- @reasonerjt
-- @shubham-pampattiwar
-- @sseago
-- @ywk253100
+- Lyndon-Li
+- anshulahuja98
+- blackpiglet
+- qiuming-best
+- reasonerjt
+- shubham-pampattiwar
+- sseago
+- ywk253100
 
 # List of usernames who may use /approve
 approvers:
-- @Lyndon-Li
-- @anshulahuja98
-- @blackpiglet
-- @qiuming-best
-- @reasonerjt
-- @shubham-pampattiwar
-- @sseago
-- @ywk253100
+- Lyndon-Li
+- anshulahuja98
+- blackpiglet
+- qiuming-best
+- reasonerjt
+- shubham-pampattiwar
+- sseago
+- ywk253100


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
This causes the [autoowners job](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-prow-auto-owners/1803691871277420544) to break and is an invalid character in the file

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.

/kind changelog-not-required