### PR TITLE
ubi: BUILDPLATFORM to build stage to enable cross compile.

### DIFF
--- a/Dockerfile-velero-restore-helper.ubi
+++ b/Dockerfile-velero-restore-helper.ubi
@@ -1,4 +1,5 @@
-FROM quay.io/konveyor/builder:ubi9-latest AS builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
+ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,4 +1,5 @@
-FROM quay.io/konveyor/builder:ubi9-latest AS builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
+ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -11,7 +12,8 @@ WORKDIR /go/src/github.com/vmware-tanzu/velero
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -mod=mod -ldflags '-extldflags "-static" -X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=konveyor-dev' -o /go/src/velero github.com/vmware-tanzu/velero/cmd/velero
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -mod=mod -ldflags '-extldflags "-static"' -o /go/src/velero-helper github.com/vmware-tanzu/velero/cmd/velero-helper
 
-FROM quay.io/konveyor/builder:ubi9-latest AS restic-builder
+FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS restic-builder
+ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?
Speed up different arch builds
before adding BUILDPLATFORM
```
❯ docker system prune --all -f &&  time docker build -f Dockerfile.ubi . --platform=linux/amd64 
docker build -f Dockerfile.ubi . --platform=linux/amd64  1.89s user 3.26s system 2% cpu 3:21.93 total
```
after adding BUILDPLATFORM
```
❯ docker system prune --all -f &&  time docker build -f Dockerfile.ubi . --platform=linux/amd64 
docker build -f Dockerfile.ubi . --platform=linux/amd64  1.73s user 3.23s system 5% cpu 1:38.16 total
and I’m doing amd64 here cause my build system is arm.
```
Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
