### PR TITLE
Downstream only: Rework of Makefile and incusion of lint

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -1,92 +1,90 @@
-# warning: verify this inside a container with following:
-# docker run -it --rm -v `pwd`:`pwd` -w `pwd` golang:1.18 bash -c "make -f Makefile.prow ci"
-# 
-# otherwise unintended system changes may include, replacing your currently installed kubectl, binaries in GOBIN, files in GOPATH/src
-# 
-# If formatting needs updating you can run
+# Warning: Verify this inside a container with the following command:
+# podman run -it --rm -v `pwd`:`pwd`:Z -w `pwd` quay.io/konveyor/builder:ubi9-v1.22.2 bash -c "make -f Makefile.prow ci"
+# podman run -it --rm -v `pwd`:`pwd`:Z -w `pwd` quay.io/konveyor/builder:ubi9-v1.22.2 bash -c "make -f Makefile.prow lint"
+#
+# Otherwise, unintended system changes may occur, including replacing your
+# currently installed binaries in GOBIN, files in GOPATH/src
+#
+# To update formatting, run:
 # GOFLAGS=-mod=mod make update
 
-GOFLAGS=-mod=mod
-CONGEN_VERSION=0.14.0
-CODEGEN_VERSION=0.22.2
-PROWBIN=/tmp/prowbin
-# Name of this Makefile
-MAKEFILE=Makefile.prow
-# emulate as close as possible upstream ci target
+# Configuration Variables
+GOFLAGS := -mod=mod
+CONGEN_VERSION := 0.14.0
+CODEGEN_VERSION := 0.22.2
+PROWBIN := /tmp/prowbin
+
+# GOPATH Setup
+GOPATH := $(shell go env GOPATH)
+GOBIN := $(GOPATH)/bin
+GOSRC := $(GOPATH)/src
+
+
 # upstream ci target: verify-modules verify all test
-#  we only need to modify verify, test, all to avoid docker usage
+# we need to modify verify, test, all to avoid usage of docker CLI
 .PHONY: ci
-ci:
-	@echo "go version is: $(shell go version)"
-	GOFLAGS=$(GOFLAGS) make verify-modules
-	make -f $(MAKEFILE) verify all test
+ci: verify-modules verify all test
+
+.PHONY: verify-modules
+verify-modules:
+	@echo "verify-modules target: calls upstream Makefile verify-modules"
+	PATH=$(PROWBIN):$(PATH) GOFLAGS=$(GOFLAGS) make verify-modules
 
 .PHONY: verify
-verify: goimports controller-gen kubectl #code-generator
-# add PROWBIN to PATH
-	@echo Verifying with PATH=$(PROWBIN):$(PATH)
-# Per
-# https://github.com/vmware-tanzu/velero/blob/dd660882d0db96d430547f39dc3694d1c1bc19f3/Makefile#L160-L163
-# code-generator tools require project to be in heirarchy such as github.com/vmware-tanzu/velero
-#  so we need to copy the project to GOPATH/src/github.com/vmware-tanzu/velero
-#  and then run verify from there
-#  otherwise the code-generator tools will fail
-	mkdir -p $(GOSRC)/github.com/vmware-tanzu/
-	cp -r . $(GOSRC)/github.com/vmware-tanzu/velero
-	cd $(GOSRC)/github.com/vmware-tanzu/velero && \
+verify: setup-env goimports controller-gen
+	@echo "Running verification scripts"
 	PATH=$(PROWBIN):$(PATH) GOFLAGS=$(GOFLAGS) hack/verify-all.sh
 
+# Build targets
 .PHONY: all
 all:
-	GOFLAGS=$(GOFLAGS) make local
-	GOFLAGS=$(GOFLAGS) BIN=velero-restore-helper make local
+	@echo "Running all targets"
+	PATH=$(PROWBIN):$(PATH) GOFLAGS=$(GOFLAGS) make local
+	PATH=$(PROWBIN):$(PATH) GOFLAGS=$(GOFLAGS) BIN=velero-restore-helper make local
 
 .PHONY: test
-# our test is modified to avoid docker usage
-test: envtest
-	@echo Testing with KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)
+test: setup-env
+	# Kubebuilder Setup
+	@echo "Setting up Kubebuilder assets..."
+	$(eval KUBEBUILDER_ASSETS := $(shell $(GOBIN)/setup-envtest use -p path | sed 's/ /\\ /g'))
+	@echo "KUBEBUILDER_ASSETS is set to $(KUBEBUILDER_ASSETS)"
+	@echo "Running tests..."
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) GOFLAGS=$(GOFLAGS) hack/test.sh
 
-GOPATH:=$(shell go env GOPATH)
-GOBIN:=$(GOPATH)/bin
-GOSRC:=$(GOPATH)/src
-#  if KUBEBUILDER_ASSETS contains space, escape it
-KUBEBUILDER_ASSETS=$(shell echo $(shell $(GOBIN)/setup-envtest use -p path) | sed 's/ /\\ /g')
-.PHONY: envtest
-envtest: $(GOBIN)/setup-envtest
+.PHONY: lint
+lint: golangci-lint
+	@echo "Running lint"
+	PATH=$(PROWBIN):$(PATH) GOFLAGS=$(GOFLAGS) hack/lint.sh
+
+# Setup the environment for testing
+.PHONY: setup-env
+setup-env: setup-envtest
+	@echo "Setting up envtest tools"
 	$(GOBIN)/setup-envtest use -p path
 
-$(GOBIN)/setup-envtest:
-	@echo Installing envtest tools
-	GOFLAGS= go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	@echo Installed envtest tools
+# Installations of dependencies
+.PHONY: goimports controller-gen golangci-lint kubectl setup-envtest
 
-.PHONY: goimports
-goimports: $(GOBIN)/goimports 
+goimports: $(GOBIN)/goimports
+controller-gen: $(GOBIN)/controller-gen
+golangci-lint: $(GOBIN)/golangci-lint
+kubectl: $(PROWBIN)/kubectl
+setup-envtest: $(GOBIN)/setup-envtest
 
 $(GOBIN)/goimports:
-	@echo Installing goimports
+	@echo "Installing goimports"
 	go install golang.org/x/tools/cmd/goimports@latest
-	@echo Installed goimports
-
-.PHONY: code-generator
-code-generator: $(GOSRC)/k8s.io/code-generator
-
-$(GOSRC)/k8s.io/code-generator:
-	mkdir -p $(GOSRC)/k8s.io/
-	cd $(GOSRC)/k8s.io/ && git clone -b v$(CODEGEN_VERSION) https://github.com/kubernetes/code-generator
-
-.PHONY: controller-gen
-controller-gen: $(GOBIN)/controller-gen
 
 $(GOBIN)/controller-gen:
+	@echo "Installing controller-gen"
 	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONGEN_VERSION)
 
-.PHONY: kubectl
-kubectl: $(PROWBIN)/kubectl
+$(GOBIN)/golangci-lint:
+	@echo "Extracting golangci-lint version from hack/build-image/Dockerfile"
+	GOLANGCI_VERSION=$$(grep -oP 'golangci-lint/master/install.sh.*\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile); \
+	echo "Installing golangci-lint version: $$GOLANGCI_VERSION"; \
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $$GOLANGCI_VERSION
 
-$(PROWBIN)/kubectl:
-	curl -LO "https://dl.k8s.io/release/$(shell curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-	chmod +x ./kubectl
-	mkdir -p $(PROWBIN)
-	mv ./kubectl $(PROWBIN)
+$(GOBIN)/setup-envtest:
+	@echo "Installing envtest tools"
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest


### PR DESCRIPTION
The rework of Makefile to make it more readable and inclusion of lint as a target.

- Removed unnecessary installation of `code-generator` which was not used in the Makefile.prow
- Removed copy of the code to separate folder, which was required by `code-generator` 
- Removed installation of kubectl, which isn't used at the moment by unit and lint jobs
- Rework of code to be eye-candy
- KUBEBUILDER_ASSETS moved inside test target, so it's not invoked for lint job
- Added fake `verify-modules` target so now `make ci` is calling exactly same targets as upstream `Makefile`
- Replaced docker with podman for running tests locally as docker is not available by default in RHEL/Fedora.

## Tests performed:
```shell
$ podman run -it --rm -v `pwd`:`pwd`:Z -w `pwd` quay.io/konveyor/builder:ubi9-v1.22.2 bash -c "make -f Makefile.prow ci"
$ podman run -it --rm -v `pwd`:`pwd`:Z -w `pwd` quay.io/konveyor/builder:ubi9-v1.22.2 bash -c "make -f Makefile.prow lint"
```