### PR TITLE
Fix #8168 - AWS secrets should not be exposed while running tests

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -20,4 +20,4 @@ jobs:
           days-before-pr-close: -1
           # Only issues made after Feb 09 2021.
           start-date: "2021-09-02T00:00:00"
-          exempt-issue-labels: "Epic,Area/CLI,Area/Cloud/AWS,Area/Cloud/Azure,Area/Cloud/GCP,Area/Cloud/vSphere,Area/CSI,Area/Design,Area/Documentation,Area/Plugins,Bug,Enhancement/User,kind/requirement,kind/refactor,kind/tech-debt,limitation,Needs investigation,Needs triage,Needs Product,P0 - Hair on fire,P1 - Important,P2 - Long-term important,P3 - Wouldn't it be nice if...,Product Requirements,Restic - GA,Restic,release-blocker,Security"
+          exempt-issue-labels: "Epic,Area/CLI,Area/Cloud/AWS,Area/Cloud/Azure,Area/Cloud/GCP,Area/Cloud/vSphere,Area/CSI,Area/Design,Area/Documentation,Area/Plugins,Bug,Enhancement/User,kind/requirement,kind/refactor,kind/tech-debt,limitation,Needs investigation,Needs triage,Needs Product,P0 - Hair on fire,P1 - Important,P2 - Long-term important,P3 - Wouldn't it be nice if...,Product Requirements,Restic - GA,Restic,release-blocker,Security,backlog"

--- a/changelogs/unreleased/7424-kaovilai
+++ b/changelogs/unreleased/7424-kaovilai
@@ -1,0 +1,1 @@
+Descriptive restore error when restoring into a terminating namespace.

--- a/changelogs/unreleased/8139-blackpiglet
+++ b/changelogs/unreleased/8139-blackpiglet
@@ -1,0 +1,1 @@
+Add resource modifier for velero restore describe CLI

--- a/changelogs/unreleased/8141-shubham-pampattiwar
+++ b/changelogs/unreleased/8141-shubham-pampattiwar
@@ -1,0 +1,1 @@
+Apply backupPVCConfig to backupPod volume spec

--- a/changelogs/unreleased/8143-Lyndon-Li
+++ b/changelogs/unreleased/8143-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8134, allow to config resource request/limit for data mover micro service pods

--- a/changelogs/unreleased/8158-Lyndon-Li
+++ b/changelogs/unreleased/8158-Lyndon-Li
@@ -1,0 +1,1 @@
+Fix issue #8155, Merge Kopia upstream commits for critical issue fixes and performance improvements

--- a/design/vgdp-micro-service/vgdp-micro-service.md
+++ b/design/vgdp-micro-service/vgdp-micro-service.md
@@ -194,7 +194,7 @@ type PodResources struct {
 ```
 The string values must mactch Kubernetes Quantity expressions; for each resource, the "request" value must not be larger than the "limit" value. Otherwise, if any one of the values fail, all the resource configurations will be ignored.  
 
-The configurations are loaded node-agent at start time, so users can change the values in the configMap any time, but the changes won't effect until node-agent restarts.    
+The configurations are loaded by node-agent at start time, so users can change the values in the configMap any time, but the changes won't effect until node-agent restarts.    
 
 
 ## node-agent

--- a/design/vgdp-micro-service/vgdp-micro-service.md
+++ b/design/vgdp-micro-service/vgdp-micro-service.md
@@ -176,6 +176,27 @@ Below diagram shows how VGDP logs are redirected:
 
 This log redirecting mechanism is thread safe since the hook acquires the write lock before writing the log buffer, so it guarantees that in the node-agent log there is no corruptions after redirecting the log, and the redirected logs and the original node-agent logs are not projected into each other.     
 
+### Resource Control
+The CPU/memory resource of backupPod/restorePod is configurable, which means users are allowed to configure resources per volume backup/restore.  
+By default, the [Best Effort policy][5] is used, and users are allowed to change it through the ```node-agent-config``` configMap. Specifically, we add below structures to the configMap:  
+``` 
+type Configs struct {
+	// PodResources is the resource config for various types of pods launched by node-agent, i.e., data mover pods.
+	PodResources *PodResources `json:"podResources,omitempty"`
+}
+
+type PodResources struct {
+	CPURequest    string `json:"cpuRequest,omitempty"`
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	CPULimit      string `json:"cpuLimit,omitempty"`
+	MemoryLimit   string `json:"memoryLimit,omitempty"`
+}
+```
+The string values must mactch Kubernetes Quantity expressions; for each resource, the "request" value must not be larger than the "limit" value. Otherwise, if any one of the values fail, all the resource configurations will be ignored.  
+
+The configurations are loaded node-agent at start time, so users can change the values in the configMap any time, but the changes won't effect until node-agent restarts.    
+
+
 ## node-agent
 node-agent is still required. Even though VGDP is now not running inside node-agent, node-agent still hosts the data mover controller which reconciles DUCR/DDCR and operates DUCR/DDCR in other steps before the VGDP instance is started, i.e., Accept, Expose, etc.  
 Privileged mode and root user are not required for node-agent anymore by Volume Snapshot Data Movement, however, they are still required by PVB(PodVolumeBackup) and PVR(PodVolumeRestore). Therefore, we will keep the node-agent deamonset as is, for any users who don't use PVB/PVR and have concern about the privileged mode/root user, they need to manually modify the deamonset spec to remove the dependencies.  
@@ -198,4 +219,5 @@ CLI is not changed.
 [2]: ../volume-snapshot-data-movement/volume-snapshot-data-movement.md
 [3]: https://kubernetes.io/blog/2022/09/02/cosi-kubernetes-object-storage-management/
 [4]: ../Implemented/node-agent-concurrency.md
+[5]: https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/
 

--- a/go.mod
+++ b/go.mod
@@ -177,4 +177,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/kopia/kopia => github.com/project-velero/kopia v0.0.0-20240417031915-e07d5b7de567
+replace github.com/kopia/kopia => github.com/project-velero/kopia v0.0.0-20240829032136-7fca59662a06

--- a/go.sum
+++ b/go.sum
@@ -613,8 +613,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
-github.com/project-velero/kopia v0.0.0-20240417031915-e07d5b7de567 h1:Gb5eZktsqgnhOfQmKWIlVA9yKvschdr8n8d6y1RLFA0=
-github.com/project-velero/kopia v0.0.0-20240417031915-e07d5b7de567/go.mod h1:2HlqZb/N6SNsWUCZzyeh9Lw29PeDRHDkMUiuQCEWt4Y=
+github.com/project-velero/kopia v0.0.0-20240829032136-7fca59662a06 h1:QLtEHOokfqpsW99nDFyU2IB47LsGhDqMICGPA+ZgjpM=
+github.com/project-velero/kopia v0.0.0-20240829032136-7fca59662a06/go.mod h1:2HlqZb/N6SNsWUCZzyeh9Lw29PeDRHDkMUiuQCEWt4Y=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/pkg/cmd/util/output/restore_describer_test.go
+++ b/pkg/cmd/util/output/restore_describer_test.go
@@ -2,15 +2,16 @@ package output
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"text/tabwriter"
 	"time"
 
-	"github.com/vmware-tanzu/velero/internal/volume"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 
+	"github.com/vmware-tanzu/velero/internal/volume"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/builder"
 	"github.com/vmware-tanzu/velero/pkg/itemoperation"
@@ -388,4 +389,29 @@ CSI Snapshot Restores:
 			assert.Equal(t, tc.expect, d.buf.String())
 		})
 	}
+}
+
+func TestDescribeResourceModifier(t *testing.T) {
+	d := &Describer{
+		Prefix: "",
+		out:    &tabwriter.Writer{},
+		buf:    &bytes.Buffer{},
+	}
+
+	d.out.Init(d.buf, 0, 8, 2, ' ', 0)
+
+	DescribeResourceModifier(d, &v1.TypedLocalObjectReference{
+		APIGroup: &v1.SchemeGroupVersion.Group,
+		Kind:     "ConfigMap",
+		Name:     "resourceModifier",
+	})
+	d.out.Flush()
+
+	expectOutput := `Resource modifier:
+  Type:  ConfigMap
+  Name:  resourceModifier
+`
+
+	fmt.Println(d.buf.String())
+	require.Equal(t, expectOutput, d.buf.String())
 }

--- a/pkg/controller/data_download_controller.go
+++ b/pkg/controller/data_download_controller.go
@@ -60,12 +60,13 @@ type DataDownloadReconciler struct {
 	restoreExposer   exposer.GenericRestoreExposer
 	nodeName         string
 	dataPathMgr      *datapath.Manager
+	podResources     v1.ResourceRequirements
 	preparingTimeout time.Duration
 	metrics          *metrics.ServerMetrics
 }
 
 func NewDataDownloadReconciler(client client.Client, mgr manager.Manager, kubeClient kubernetes.Interface, dataPathMgr *datapath.Manager,
-	nodeName string, preparingTimeout time.Duration, logger logrus.FieldLogger, metrics *metrics.ServerMetrics) *DataDownloadReconciler {
+	podResources v1.ResourceRequirements, nodeName string, preparingTimeout time.Duration, logger logrus.FieldLogger, metrics *metrics.ServerMetrics) *DataDownloadReconciler {
 	return &DataDownloadReconciler{
 		client:           client,
 		kubeClient:       kubeClient,
@@ -75,6 +76,7 @@ func NewDataDownloadReconciler(client client.Client, mgr manager.Manager, kubeCl
 		nodeName:         nodeName,
 		restoreExposer:   exposer.NewGenericRestoreExposer(kubeClient, logger),
 		dataPathMgr:      dataPathMgr,
+		podResources:     podResources,
 		preparingTimeout: preparingTimeout,
 		metrics:          metrics,
 	}
@@ -179,7 +181,7 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// Expose() will trigger to create one pod whose volume is restored by a given volume snapshot,
 		// but the pod maybe is not in the same node of the current controller, so we need to return it here.
 		// And then only the controller who is in the same node could do the rest work.
-		err = r.restoreExposer.Expose(ctx, getDataDownloadOwnerObject(dd), dd.Spec.TargetVolume.PVC, dd.Spec.TargetVolume.Namespace, hostingPodLabels, dd.Spec.OperationTimeout.Duration)
+		err = r.restoreExposer.Expose(ctx, getDataDownloadOwnerObject(dd), dd.Spec.TargetVolume.PVC, dd.Spec.TargetVolume.Namespace, hostingPodLabels, r.podResources, dd.Spec.OperationTimeout.Duration)
 		if err != nil {
 			if err := r.client.Get(ctx, req.NamespacedName, dd); err != nil {
 				if !apierrors.IsNotFound(err) {

--- a/pkg/controller/data_download_controller_test.go
+++ b/pkg/controller/data_download_controller_test.go
@@ -140,7 +140,7 @@ func initDataDownloadReconcilerWithError(objects []runtime.Object, needError ...
 
 	dataPathMgr := datapath.NewManager(1)
 
-	return NewDataDownloadReconciler(fakeClient, nil, fakeKubeClient, dataPathMgr, "test-node", time.Minute*5, velerotest.NewLogger(), metrics.NewServerMetrics()), nil
+	return NewDataDownloadReconciler(fakeClient, nil, fakeKubeClient, dataPathMgr, corev1.ResourceRequirements{}, "test-node", time.Minute*5, velerotest.NewLogger(), metrics.NewServerMetrics()), nil
 }
 
 func TestDataDownloadReconcile(t *testing.T) {
@@ -441,7 +441,7 @@ func TestDataDownloadReconcile(t *testing.T) {
 					r.restoreExposer = func() exposer.GenericRestoreExposer {
 						ep := exposermockes.NewGenericRestoreExposer(t)
 						if test.isExposeErr {
-							ep.On("Expose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("Error to expose restore exposer"))
+							ep.On("Expose", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("Error to expose restore exposer"))
 						} else if test.notNilExpose {
 							hostingPod := builder.ForPod("test-ns", "test-name").Volumes(&corev1.Volume{Name: "test-pvc"}).Result()
 							hostingPod.ObjectMeta.SetUID("test-uid")
@@ -959,7 +959,7 @@ func (dt *ddResumeTestHelper) resumeCancellableDataPath(_ *DataUploadReconciler,
 	return dt.resumeErr
 }
 
-func (dt *ddResumeTestHelper) Expose(context.Context, corev1.ObjectReference, string, string, map[string]string, time.Duration) error {
+func (dt *ddResumeTestHelper) Expose(context.Context, corev1.ObjectReference, string, string, map[string]string, corev1.ResourceRequirements, time.Duration) error {
 	return nil
 }
 

--- a/pkg/controller/data_upload_controller.go
+++ b/pkg/controller/data_upload_controller.go
@@ -73,13 +73,14 @@ type DataUploadReconciler struct {
 	dataPathMgr         *datapath.Manager
 	loadAffinity        *nodeagent.LoadAffinity
 	backupPVCConfig     map[string]nodeagent.BackupPVC
+	podResources        corev1.ResourceRequirements
 	preparingTimeout    time.Duration
 	metrics             *metrics.ServerMetrics
 }
 
 func NewDataUploadReconciler(client client.Client, mgr manager.Manager, kubeClient kubernetes.Interface, csiSnapshotClient snapshotter.SnapshotV1Interface,
-	dataPathMgr *datapath.Manager, loadAffinity *nodeagent.LoadAffinity, backupPVCConfig map[string]nodeagent.BackupPVC, clock clocks.WithTickerAndDelayedExecution,
-	nodeName string, preparingTimeout time.Duration, log logrus.FieldLogger, metrics *metrics.ServerMetrics) *DataUploadReconciler {
+	dataPathMgr *datapath.Manager, loadAffinity *nodeagent.LoadAffinity, backupPVCConfig map[string]nodeagent.BackupPVC, podResources corev1.ResourceRequirements,
+	clock clocks.WithTickerAndDelayedExecution, nodeName string, preparingTimeout time.Duration, log logrus.FieldLogger, metrics *metrics.ServerMetrics) *DataUploadReconciler {
 	return &DataUploadReconciler{
 		client:              client,
 		mgr:                 mgr,
@@ -92,6 +93,7 @@ func NewDataUploadReconciler(client client.Client, mgr manager.Manager, kubeClie
 		dataPathMgr:         dataPathMgr,
 		loadAffinity:        loadAffinity,
 		backupPVCConfig:     backupPVCConfig,
+		podResources:        podResources,
 		preparingTimeout:    preparingTimeout,
 		metrics:             metrics,
 	}
@@ -795,6 +797,7 @@ func (r *DataUploadReconciler) setupExposeParam(du *velerov2alpha1api.DataUpload
 			VolumeSize:       pvc.Spec.Resources.Requests[corev1.ResourceStorage],
 			Affinity:         r.loadAffinity,
 			BackupPVCConfig:  r.backupPVCConfig,
+			Resources:        r.podResources,
 		}, nil
 	}
 	return nil, nil

--- a/pkg/controller/data_upload_controller_test.go
+++ b/pkg/controller/data_upload_controller_test.go
@@ -232,7 +232,7 @@ func initDataUploaderReconcilerWithError(needError ...error) (*DataUploadReconci
 	fakeKubeClient := clientgofake.NewSimpleClientset(daemonSet)
 
 	return NewDataUploadReconciler(fakeClient, nil, fakeKubeClient, fakeSnapshotClient.SnapshotV1(), dataPathMgr, nil, map[string]nodeagent.BackupPVC{},
-		testclocks.NewFakeClock(now), "test-node", time.Minute*5, velerotest.NewLogger(), metrics.NewServerMetrics()), nil
+		corev1.ResourceRequirements{}, testclocks.NewFakeClock(now), "test-node", time.Minute*5, velerotest.NewLogger(), metrics.NewServerMetrics()), nil
 }
 
 func dataUploadBuilder() *builder.DataUploadBuilder {

--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -435,7 +435,7 @@ func (e *csiSnapshotExposer) createBackupPod(ctx context.Context, ownerObject co
 	}
 
 	var gracePeriod int64 = 0
-	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, backupPVC.Spec.VolumeMode)
+	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, backupPVC.Spec.VolumeMode, true)
 	volumeMounts = append(volumeMounts, podInfo.volumeMounts...)
 
 	volumes := []corev1.Volume{{
@@ -443,6 +443,7 @@ func (e *csiSnapshotExposer) createBackupPod(ctx context.Context, ownerObject co
 		VolumeSource: corev1.VolumeSource{
 			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 				ClaimName: backupPVC.Name,
+				ReadOnly:  true,
 			},
 		},
 	}}

--- a/pkg/exposer/generic_restore.go
+++ b/pkg/exposer/generic_restore.go
@@ -310,7 +310,7 @@ func (e *genericRestoreExposer) createRestorePod(ctx context.Context, ownerObjec
 	}
 
 	var gracePeriod int64 = 0
-	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, targetPVC.Spec.VolumeMode)
+	volumeMounts, volumeDevices, volumePath := kube.MakePodPVCAttachment(volumeName, targetPVC.Spec.VolumeMode, false)
 	volumeMounts = append(volumeMounts, podInfo.volumeMounts...)
 
 	volumes := []corev1.Volume{{

--- a/pkg/exposer/generic_restore_test.go
+++ b/pkg/exposer/generic_restore_test.go
@@ -180,7 +180,7 @@ func TestRestoreExpose(t *testing.T) {
 				}
 			}
 
-			err := exposer.Expose(context.Background(), ownerObject, test.targetPVCName, test.sourceNamespace, map[string]string{}, time.Millisecond)
+			err := exposer.Expose(context.Background(), ownerObject, test.targetPVCName, test.sourceNamespace, map[string]string{}, corev1.ResourceRequirements{}, time.Millisecond)
 			assert.EqualError(t, err, test.err)
 		})
 	}

--- a/pkg/exposer/mocks/generic_restore.go
+++ b/pkg/exposer/mocks/generic_restore.go
@@ -26,17 +26,17 @@ func (_m *GenericRestoreExposer) CleanUp(_a0 context.Context, _a1 v1.ObjectRefer
 	_m.Called(_a0, _a1)
 }
 
-// Expose provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
-func (_m *GenericRestoreExposer) Expose(_a0 context.Context, _a1 v1.ObjectReference, _a2 string, _a3 string, _a4 map[string]string, _a5 time.Duration) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
+// Expose provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6
+func (_m *GenericRestoreExposer) Expose(_a0 context.Context, _a1 v1.ObjectReference, _a2 string, _a3 string, _a4 map[string]string, _a5 v1.ResourceRequirements, _a6 time.Duration) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Expose")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, v1.ObjectReference, string, string, map[string]string, time.Duration) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(0).(func(context.Context, v1.ObjectReference, string, string, map[string]string, v1.ResourceRequirements, time.Duration) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/nodeagent/node_agent.go
+++ b/pkg/nodeagent/node_agent.go
@@ -70,6 +70,13 @@ type BackupPVC struct {
 	ReadOnly bool `json:"readOnly,omitempty"`
 }
 
+type PodResources struct {
+	CPURequest    string `json:"cpuRequest,omitempty"`
+	MemoryRequest string `json:"memoryRequest,omitempty"`
+	CPULimit      string `json:"cpuLimit,omitempty"`
+	MemoryLimit   string `json:"memoryLimit,omitempty"`
+}
+
 type Configs struct {
 	// LoadConcurrency is the config for data path load concurrency per node.
 	LoadConcurrency *LoadConcurrency `json:"loadConcurrency,omitempty"`
@@ -79,6 +86,9 @@ type Configs struct {
 
 	// BackupPVCConfig is the config for backupPVC (intermediate PVC) of snapshot data movement
 	BackupPVCConfig map[string]BackupPVC `json:"backupPVC,omitempty"`
+
+	// PodResources is the resource config for various types of pods launched by node-agent, i.e., data mover pods.
+	PodResources *PodResources `json:"podResources,omitempty"`
 }
 
 // IsRunning checks if the node agent daemonset is running properly. If not, return the error found

--- a/pkg/repository/config/aws.go
+++ b/pkg/repository/config/aws.go
@@ -34,6 +34,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// getS3CredentialsFunc is used to make testing more convenient
+var getS3CredentialsFunc = GetS3Credentials
+
 const (
 	// AWS specific environment variable
 	awsProfileEnvVar         = "AWS_PROFILE"
@@ -63,7 +66,7 @@ func GetS3ResticEnvVars(config map[string]string) (map[string]string, error) {
 	// GetS3ResticEnvVars reads the AWS config, from files and envs
 	// if needed assumes the role and returns the session credentials
 	// setting these variables emulates what would happen for example when using kube2iam
-	if creds, err := GetS3Credentials(config); err == nil && creds != nil {
+	if creds, err := getS3CredentialsFunc(config); err == nil && creds != nil {
 		result[awsKeyIDEnvVar] = creds.AccessKeyID
 		result[awsSecretKeyEnvVar] = creds.SecretAccessKey
 		result[awsSessTokenEnvVar] = creds.SessionToken

--- a/pkg/repository/config/aws_test.go
+++ b/pkg/repository/config/aws_test.go
@@ -27,14 +27,18 @@ import (
 
 func TestGetS3ResticEnvVars(t *testing.T) {
 	testCases := []struct {
-		name     string
-		config   map[string]string
-		expected map[string]string
+		name             string
+		config           map[string]string
+		expected         map[string]string
+		getS3Credentials func(config map[string]string) (*aws.Credentials, error)
 	}{
 		{
 			name:     "when config is empty, no env vars are returned",
 			config:   map[string]string{},
 			expected: map[string]string{},
+			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+				return nil, nil
+			},
 		},
 		{
 			name: "when config contains profile key, profile env var is set with profile value",
@@ -53,16 +57,41 @@ func TestGetS3ResticEnvVars(t *testing.T) {
 			expected: map[string]string{
 				"AWS_SHARED_CREDENTIALS_FILE": "/tmp/credentials/path/to/secret",
 			},
+			getS3Credentials: func(config map[string]string) (*aws.Credentials, error) {
+				return nil, nil
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+
+			// Mock GetS3Credentials
+			if tc.getS3Credentials != nil {
+				getS3CredentialsFunc = tc.getS3Credentials
+			} else {
+				getS3CredentialsFunc = GetS3Credentials
+			}
+
 			actual, err := GetS3ResticEnvVars(tc.config)
 
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expected, actual)
+			// Avoid direct comparison of expected and actual to prevent exposing secrets.
+			// This may occur if the test doesn't set getS3Credentials func correctly.
+			if !reflect.DeepEqual(tc.expected, actual) {
+				t.Errorf("Expected and actual results do not match for test case %q", tc.name)
+				for key, value := range actual {
+					if expVal, err := tc.expected[key]; !err || expVal != value {
+						if actualVal, ok := actual[key]; !ok {
+							t.Errorf("Key %q is missing in actual result", key)
+						} else if expVal != actualVal {
+							t.Errorf("Key %q: expected value %q", key, expVal)
+						}
+					}
+				}
+			}
+
 		})
 	}
 }
@@ -117,6 +146,11 @@ func TestGetS3CredentialsCorrectlyUseProfile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Ensure env variables do not set AWS config entries
+			t.Setenv("AWS_ACCESS_KEY_ID", "")
+			t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+			t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+
 			tmpFile, err := os.CreateTemp("", "velero-test-aws-credentials")
 			defer os.Remove(tmpFile.Name())
 			if err != nil {
@@ -129,6 +163,7 @@ func TestGetS3CredentialsCorrectlyUseProfile(t *testing.T) {
 				t.Errorf("GetS3Credentials() error = %v", err)
 				return
 			}
+
 			tt.args.config["credentialsFile"] = tmpFile.Name()
 			got, err := GetS3Credentials(tt.args.config)
 			if (err != nil) != tt.wantErr {
@@ -136,10 +171,10 @@ func TestGetS3CredentialsCorrectlyUseProfile(t *testing.T) {
 				return
 			}
 			if !reflect.DeepEqual(got.AccessKeyID, tt.want.AccessKeyID) {
-				t.Errorf("GetS3Credentials() got = %v, want %v", got.AccessKeyID, tt.want.AccessKeyID)
+				t.Errorf("GetS3Credentials() want %v", tt.want.AccessKeyID)
 			}
 			if !reflect.DeepEqual(got.SecretAccessKey, tt.want.SecretAccessKey) {
-				t.Errorf("GetS3Credentials() got = %v, want %v", got.SecretAccessKey, tt.want.SecretAccessKey)
+				t.Errorf("GetS3Credentials() want %v", tt.want.SecretAccessKey)
 			}
 		})
 	}

--- a/pkg/uploader/kopia/block_restore.go
+++ b/pkg/uploader/kopia/block_restore.go
@@ -41,7 +41,7 @@ var _ restore.Output = &BlockOutput{}
 
 const bufferSize = 128 * 1024
 
-func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remoteFile fs.File) error {
+func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remoteFile fs.File, progressCb restore.FileWriteProgress) error {
 	remoteReader, err := remoteFile.Open(ctx)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open remote file %s", remoteFile.Name())
@@ -70,6 +70,7 @@ func (o *BlockOutput) WriteFile(ctx context.Context, relativePath string, remote
 			offset := 0
 			for bytesToWrite > 0 {
 				if bytesWritten, err := targetFile.Write(buffer[offset:bytesToWrite]); err == nil {
+					progressCb(int64(bytesWritten))
 					bytesToWrite -= bytesWritten
 					offset += bytesWritten
 				} else {

--- a/pkg/util/kube/pvc_pv.go
+++ b/pkg/util/kube/pvc_pv.go
@@ -346,7 +346,7 @@ func IsPVCBound(pvc *corev1api.PersistentVolumeClaim) bool {
 }
 
 // MakePodPVCAttachment returns the volume mounts and devices for a pod needed to attach a PVC
-func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVolumeMode) ([]corev1api.VolumeMount, []corev1api.VolumeDevice, string) {
+func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVolumeMode, readOnly bool) ([]corev1api.VolumeMount, []corev1api.VolumeDevice, string) {
 	var volumeMounts []corev1api.VolumeMount = nil
 	var volumeDevices []corev1api.VolumeDevice = nil
 	volumePath := "/" + volumeName
@@ -360,6 +360,7 @@ func MakePodPVCAttachment(volumeName string, volumeMode *corev1api.PersistentVol
 		volumeMounts = []corev1api.VolumeMount{{
 			Name:      volumeName,
 			MountPath: volumePath,
+			ReadOnly:  readOnly,
 		}}
 	}
 

--- a/pkg/util/kube/pvc_pv_test.go
+++ b/pkg/util/kube/pvc_pv_test.go
@@ -1386,6 +1386,7 @@ func TestMakePodPVCAttachment(t *testing.T) {
 		name                 string
 		volumeName           string
 		volumeMode           corev1api.PersistentVolumeMode
+		readOnly             bool
 		expectedVolumeMount  []corev1api.VolumeMount
 		expectedVolumeDevice []corev1api.VolumeDevice
 		expectedVolumePath   string
@@ -1393,10 +1394,12 @@ func TestMakePodPVCAttachment(t *testing.T) {
 		{
 			name:       "no volume mode specified",
 			volumeName: "volume-1",
+			readOnly:   true,
 			expectedVolumeMount: []corev1api.VolumeMount{
 				{
 					Name:      "volume-1",
 					MountPath: "/volume-1",
+					ReadOnly:  true,
 				},
 			},
 			expectedVolumePath: "/volume-1",
@@ -1405,10 +1408,12 @@ func TestMakePodPVCAttachment(t *testing.T) {
 			name:       "fs mode specified",
 			volumeName: "volume-2",
 			volumeMode: corev1api.PersistentVolumeFilesystem,
+			readOnly:   true,
 			expectedVolumeMount: []corev1api.VolumeMount{
 				{
 					Name:      "volume-2",
 					MountPath: "/volume-2",
+					ReadOnly:  true,
 				},
 			},
 			expectedVolumePath: "/volume-2",
@@ -1425,6 +1430,20 @@ func TestMakePodPVCAttachment(t *testing.T) {
 			},
 			expectedVolumePath: "/volume-3",
 		},
+		{
+			name:       "fs mode specified with readOnly as false",
+			volumeName: "volume-4",
+			readOnly:   false,
+			volumeMode: corev1api.PersistentVolumeFilesystem,
+			expectedVolumeMount: []corev1api.VolumeMount{
+				{
+					Name:      "volume-4",
+					MountPath: "/volume-4",
+					ReadOnly:  false,
+				},
+			},
+			expectedVolumePath: "/volume-4",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1434,11 +1453,14 @@ func TestMakePodPVCAttachment(t *testing.T) {
 				volMode = &tc.volumeMode
 			}
 
-			mount, device, path := MakePodPVCAttachment(tc.volumeName, volMode)
+			mount, device, path := MakePodPVCAttachment(tc.volumeName, volMode, tc.readOnly)
 
 			assert.Equal(t, tc.expectedVolumeMount, mount)
 			assert.Equal(t, tc.expectedVolumeDevice, device)
 			assert.Equal(t, tc.expectedVolumePath, path)
+			if tc.expectedVolumeMount != nil {
+				assert.Equal(t, tc.expectedVolumeMount[0].ReadOnly, tc.readOnly)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

Changed the tests to use mocked function that will not read actual secrets from env variables nor AWS config file that may be on the system that is running tests.
    
As a second guard against exposed secrets comparison for the values does not shows the actual values for the AWS data. This is to prevent situation where programming error may still allow the test to read AWS config/env variables instead of using mocked function.

This change also fixes the test run on the system with AWS creds where the test was failing.

# Does your change fix a particular issue?

Fixes #8168

# Please indicate you've done the following:

- [x] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [x] [Created a changelog file](https://velero.io/docs/v1.5/code-standards/#adding-a-changelog) or added `/kind changelog-not-required` as a comment on this pull request.
- [x] Updated the corresponding documentation in `site/content/docs/main`.
