### PR TITLE
Downstream lint fix error

### DIFF
--- a/pkg/repository/udmrepo/kopialib/backend/common_kopia_algorithms_test.go
+++ b/pkg/repository/udmrepo/kopialib/backend/common_kopia_algorithms_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestSetupNewRepoAlgorithms(t *testing.T) {
-
 	testCases := []struct {
 		name     string
 		envVars  map[string]string


### PR DESCRIPTION
Downstream only - fix lint error in downtream change
    
This fixes the PR #334 where one additional line was in the code. This was not exposed previously as we did not had downstream CI Lint jobs.

Allows the job proposed in the https://github.com/openshift/release/pull/55969 to pass.