### PR TITLE
issue 8249: disable selinux relabel for backupPod

### DIFF
--- a/pkg/exposer/csi_snapshot.go
+++ b/pkg/exposer/csi_snapshot.go
@@ -546,6 +546,9 @@ func (e *csiSnapshotExposer) createBackupPod(
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: &userID,
+				SELinuxOptions: &corev1.SELinuxOptions{
+					Type: "spc_t",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
to create test image
```
ghcr.io/kaovilai/velero:kondev-sptc
```

```
docker buildx build --platform=linux/amd64,linux/arm64 -t $(ghcr_tag) -f Dockerfile.ubi . --push
```

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
