### PR TITLE
run oadp-operator e2e test from the velero repo

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -139,4 +139,4 @@ local-build-test-e2e: build push clone-oadp-operator
 .PHONY: local-test-e2e
 local-test-e2e: clone-oadp-operator
 	@echo "Running oadp-operator e2e tests locally"
-	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) && export OPENSHIFT_CI=false && export GINKGO_ARGS=$(GINKGO_ARGS) && make test-e2e && popd
+	pushd $(OADP_E2E_DIR) && VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) OPENSHIFT_CI=false GINKGO_ARGS=$(GINKGO_ARGS) make test-e2e && popd

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -138,7 +138,7 @@ test-e2e: clone-oadp-operator
 .PHONY: local-build-test-e2e
 local-build-test-e2e: build push clone-oadp-operator
 	@echo "Building Velero and Running oadp-operator e2e tests locally"
-	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) && export OPENSHIFT_CI=false && make test-e2e && popd
+	pushd $(OADP_E2E_DIR) && VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) OPENSHIFT_CI=false make test-e2e && popd
 
 # to run just one test, export GINKGO_ARGS="--ginkgo.focus='MySQL application CSI'"
 # do NOT build, test locally

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -122,6 +122,12 @@ push:
 	@echo "Pushing image: $(LOCAL_BUILT_IMAGE)"
 	docker push $(LOCAL_BUILT_IMAGE)
 
+# deploy oadp-operator, potentially used by prow jobs
+.PHONY: deploy-olm
+deploy-olm: clone-oadp-operator
+	@echo "Deploying oadp-operator"
+	pushd $(OADP_E2E_DIR) && make deploy-olm && popd
+
 # test-e2e is to be used by prow.
 .PHONY: test-e2e
 test-e2e: clone-oadp-operator

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -22,7 +22,7 @@ GOSRC := $(GOPATH)/src
 # Prow settings for e2e tests
 OADP_E2E_DIR := /tmp/oadp-operator
 OADP_E2E_BRANCH := master
-VELERO_IMAGE := quay.io/konveyor/velero:latest
+VELERO_IMAGE ?= quay.io/konveyor/velero:latest
 
 # upstream ci target: verify-modules verify all test
 # we need to modify verify, test, all to avoid usage of docker CLI

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -23,11 +23,12 @@ GOSRC := $(GOPATH)/src
 OADP_E2E_DIR := /tmp/oadp-operator
 OADP_E2E_BRANCH := master
 VELERO_IMAGE ?= quay.io/konveyor/velero:latest
-LOCAL_BUILT_IMAGE=ttl.sh/velero-$(shell git rev-parse --short HEAD):1h
 CLUSTER_ARCH ?= $(shell oc get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')
 CLUSTER_OS ?= $(shell oc get node -o jsonpath='{.items[0].status.nodeInfo.operatingSystem}')
 DOCKER_BUILD_ARGS = --platform=$(CLUSTER_OS)/$(CLUSTER_ARCH)
 GINKGO_ARGS ?= ""  # by default (empty) run all tests, otherwise specify a test to run
+LOCAL_BUILT_IMAGE=ttl.sh/velero-$(CLUSTER_ARCH)-$(shell git rev-parse --short HEAD):1h
+
 
 
 # upstream ci target: verify-modules verify all test

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -19,6 +19,10 @@ GOPATH := $(shell go env GOPATH)
 GOBIN := $(GOPATH)/bin
 GOSRC := $(GOPATH)/src
 
+# Prow settings for e2e tests
+E2E_TEST_DIR := /tmp/oadp-operator
+E2E_TEST_BRANCH := master
+VELERO_IMAGE := quay.io/konveyor/velero:latest
 
 # upstream ci target: verify-modules verify all test
 # we need to modify verify, test, all to avoid usage of docker CLI
@@ -88,3 +92,16 @@ $(GOBIN)/golangci-lint:
 $(GOBIN)/setup-envtest:
 	@echo "Installing envtest tools"
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: clone-oadp-operator
+clone-oadp-operator:
+	@echo "Cloning oadp-operator"
+	rm -rf $(E2E_TEST_DIR)
+	git clone --depth 1 --single-branch --branch $(E2E_TEST_BRANCH) https://github.com/openshift/oadp-operator.git $(E2E_TEST_DIR)
+
+# to run just one test, use `make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application CSI'"`
+.PHONY: test-e2e
+test-e2e: clone-oadp-operator
+	@echo "Running oadp-operator e2e tests"
+	pushd $(E2E_TEST_DIR) && export VELERO_IMAGE=$(VELERO_IMAGE) && make test-e2e && popd
+

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -126,7 +126,7 @@ push:
 .PHONY: test-e2e
 test-e2e: clone-oadp-operator
 	@echo "Running oadp-operator e2e tests"
-	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(VELERO_IMAGE) && make test-e2e && popd
+	pushd $(OADP_E2E_DIR) && VELERO_IMAGE=$(VELERO_IMAGE) make test-e2e && popd
 
 # build and test locally
 .PHONY: local-build-test-e2e

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -101,9 +101,8 @@ $(GOBIN)/setup-envtest:
 	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 .PHONY: clone-oadp-operator
-clone-oadp-operator:
+clone-oadp-operator: clean-oadp-operator
 	@echo "Cloning oadp-operator"
-	rm -rf $(OADP_E2E_DIR)
 	git clone --depth 1 --single-branch --branch $(OADP_E2E_BRANCH) https://github.com/openshift/oadp-operator.git $(OADP_E2E_DIR)
 
 .PHONY: clean-oadp-operator

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -20,8 +20,8 @@ GOBIN := $(GOPATH)/bin
 GOSRC := $(GOPATH)/src
 
 # Prow settings for e2e tests
-E2E_TEST_DIR := /tmp/oadp-operator
-E2E_TEST_BRANCH := master
+OADP_E2E_DIR := /tmp/oadp-operator
+OADP_E2E_BRANCH := master
 VELERO_IMAGE := quay.io/konveyor/velero:latest
 
 # upstream ci target: verify-modules verify all test
@@ -96,12 +96,17 @@ $(GOBIN)/setup-envtest:
 .PHONY: clone-oadp-operator
 clone-oadp-operator:
 	@echo "Cloning oadp-operator"
-	rm -rf $(E2E_TEST_DIR)
-	git clone --depth 1 --single-branch --branch $(E2E_TEST_BRANCH) https://github.com/openshift/oadp-operator.git $(E2E_TEST_DIR)
+	rm -rf $(OADP_E2E_DIR)
+	git clone --depth 1 --single-branch --branch $(OADP_E2E_BRANCH) https://github.com/openshift/oadp-operator.git $(OADP_E2E_DIR)
+
+.PHONY: clean-oadp-operator
+clean-oadp-operator:
+	@echo "Cleaning oadp-operator"
+	rm -rf $(OADP_E2E_DIR)
 
 # to run just one test, use `make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application CSI'"`
 .PHONY: test-e2e
 test-e2e: clone-oadp-operator
 	@echo "Running oadp-operator e2e tests"
-	pushd $(E2E_TEST_DIR) && export VELERO_IMAGE=$(VELERO_IMAGE) && make test-e2e && popd
+	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(VELERO_IMAGE) && make test-e2e && popd
 

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -23,6 +23,12 @@ GOSRC := $(GOPATH)/src
 OADP_E2E_DIR := /tmp/oadp-operator
 OADP_E2E_BRANCH := master
 VELERO_IMAGE ?= quay.io/konveyor/velero:latest
+LOCAL_BUILT_IMAGE=ttl.sh/velero-$(shell git rev-parse --short HEAD):1h
+CLUSTER_ARCH ?= $(shell oc get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}')
+CLUSTER_OS ?= $(shell oc get node -o jsonpath='{.items[0].status.nodeInfo.operatingSystem}')
+DOCKER_BUILD_ARGS = --platform=$(CLUSTER_OS)/$(CLUSTER_ARCH)
+GINKGO_ARGS ?= ""  # by default (empty) run all tests, otherwise specify a test to run
+
 
 # upstream ci target: verify-modules verify all test
 # we need to modify verify, test, all to avoid usage of docker CLI
@@ -104,9 +110,33 @@ clean-oadp-operator:
 	@echo "Cleaning oadp-operator"
 	rm -rf $(OADP_E2E_DIR)
 
-# to run just one test, use `make test-e2e GINKGO_ARGS="--ginkgo.focus='MySQL application CSI'"`
+# build the Dockerfile.ubi
+.PHONY: build
+build:
+	@echo "Building Dockerfile.ubi with tag: $(LOCAL_BUILT_IMAGE)"
+	docker build -t $(LOCAL_BUILT_IMAGE) -f Dockerfile.ubi . $(DOCKER_BUILD_ARGS)
+
+# push the image to ttl.sh
+.PHONY: push
+push:
+	@echo "Pushing image: $(LOCAL_BUILT_IMAGE)"
+	docker push $(LOCAL_BUILT_IMAGE)
+
+# test-e2e is to be used by prow.
 .PHONY: test-e2e
 test-e2e: clone-oadp-operator
 	@echo "Running oadp-operator e2e tests"
 	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(VELERO_IMAGE) && make test-e2e && popd
 
+# build and test locally
+.PHONY: local-build-test-e2e
+local-build-test-e2e: build push clone-oadp-operator
+	@echo "Building Velero and Running oadp-operator e2e tests locally"
+	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) && export OPENSHIFT_CI=false && make test-e2e && popd
+
+# to run just one test, export GINKGO_ARGS="--ginkgo.focus='MySQL application CSI'"
+# do NOT build, test locally
+.PHONY: local-test-e2e
+local-test-e2e: clone-oadp-operator
+	@echo "Running oadp-operator e2e tests locally"
+	pushd $(OADP_E2E_DIR) && export VELERO_IMAGE=$(LOCAL_BUILT_IMAGE) && export OPENSHIFT_CI=false && export GINKGO_ARGS=$(GINKGO_ARGS) && make test-e2e && popd


### PR DESCRIPTION
execute openshift/oadp-operator e2e tests directly against the velero repo locally or via prow ci

Thank you for contributing to Velero!

# Please add a summary of your change
execute openshift/oadp-operator e2e tests directly against the velero repo locally or via prow ci

# to test
optional: update the VELERO_IMAGE variable
execute: make -f Makefile.prow test-e2e