### PR TITLE
Fix OADP-5111: Backups partially fails when backing up all namespaces

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -739,6 +739,11 @@ func getNamespacesManagedByArgoCD(kbClient kbclient.Client, includedNamespaces [
 	for _, nsName := range includedNamespaces {
 		ns := corev1api.Namespace{}
 		if err := kbClient.Get(context.Background(), kbclient.ObjectKey{Name: nsName}, &ns); err != nil {
+			// check for only those ns that exist and are included in backup
+			// here we ignore cases like "" or "*" specified under includedNamespaces
+			if apierrors.IsNotFound(err) {
+				continue
+			}
 			log.WithError(err).Errorf("error getting namespace %s", nsName)
 			continue
 		}


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
