### PR TITLE
OADP-5611: Copy SecurityContext from Containers[0] if present for PVR

### DIFF
--- a/pkg/restore/actions/pod_volume_restore_action.go
+++ b/pkg/restore/actions/pod_volume_restore_action.go
@@ -147,14 +147,23 @@ func (a *PodVolumeRestoreAction) Execute(input *velero.RestoreItemActionExecuteI
 	runAsUser, runAsGroup, allowPrivilegeEscalation, secCtx := getSecurityContext(log, config)
 
 	var securityContext corev1.SecurityContext
-	if runAsUser == "" && runAsGroup == "" && allowPrivilegeEscalation == "" && secCtx == "" {
-		securityContext = defaultSecurityCtx()
-	} else {
+	securityContextSet := false
+	// Use securityContext settings from configmap if available
+	if runAsUser != "" || runAsGroup != "" || allowPrivilegeEscalation != "" || secCtx != "" {
 		securityContext, err = kube.ParseSecurityContext(runAsUser, runAsGroup, allowPrivilegeEscalation, secCtx)
 		if err != nil {
 			log.Errorf("Using default securityContext values, couldn't parse securityContext requirements: %s.", err)
-			securityContext = defaultSecurityCtx()
+		} else {
+			securityContextSet = true
 		}
+	}
+	// if first container in pod has a SecurityContext set, then copy this security context
+	if len(pod.Spec.Containers) != 0 && pod.Spec.Containers[0].SecurityContext != nil {
+		securityContext = *pod.Spec.Containers[0].SecurityContext.DeepCopy()
+		securityContextSet = true
+	}
+	if !securityContextSet {
+		securityContext = defaultSecurityCtx()
 	}
 
 	initContainerBuilder := newRestoreInitContainerBuilder(image, string(input.Restore.UID))


### PR DESCRIPTION
Thank you for contributing to Velero!

# Please add a summary of your change
Velero 1.15.1 added a change to set a default SecurityContext on the fs-backup InitContainer to fix a bug related to pod security standards enforcement. In an OpenShift environment, when the pod was created by a non-admin user, using this default SecurityContext with `runAsUser` set based on the current (velero) user breaks because this forces the `openshift.io/scc` annotation to the default privileged level of the velero SA.

This fix copies the SecurityContext from the pod's first Container, if that container has a non-nil SecurityContext.

Upstream equiv: https://github.com/vmware-tanzu/velero/pull/8712

