### PR TITLE
Fix for OADP-5033 - cherry pick of upstream change

### DIFF
--- a/changelogs/unreleased/8774-mpryc
+++ b/changelogs/unreleased/8774-mpryc
@@ -1,0 +1,1 @@
+host_pods should not be mandatory to node-agent

--- a/pkg/cmd/cli/nodeagent/server.go
+++ b/pkg/cmd/cli/nodeagent/server.go
@@ -79,6 +79,8 @@ const (
 	// files will be written to
 	defaultCredentialsDirectory = "/tmp/credentials"
 
+	defaultHostPodsPath = "/host_pods"
+
 	defaultResourceTimeout         = 10 * time.Minute
 	defaultDataMoverPrepareTimeout = 30 * time.Minute
 	defaultDataPathConcurrentNum   = 1
@@ -388,8 +390,12 @@ func (s *nodeAgentServer) waitCacheForResume() error {
 // validatePodVolumesHostPath validates that the pod volumes path contains a
 // directory for each Pod running on this node
 func (s *nodeAgentServer) validatePodVolumesHostPath(client kubernetes.Interface) error {
-	files, err := s.fileSystem.ReadDir("/host_pods/")
+	files, err := s.fileSystem.ReadDir(defaultHostPodsPath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			s.logger.Warnf("Pod volumes host path [%s] doesn't exist, fs-backup is disabled", defaultHostPodsPath)
+			return nil
+		}
 		return errors.Wrap(err, "could not read pod volumes host path")
 	}
 
@@ -420,7 +426,7 @@ func (s *nodeAgentServer) validatePodVolumesHostPath(client kubernetes.Interface
 			valid = false
 			s.logger.WithFields(logrus.Fields{
 				"pod":  fmt.Sprintf("%s/%s", pod.GetNamespace(), pod.GetName()),
-				"path": "/host_pods/" + dirName,
+				"path": defaultHostPodsPath + "/" + dirName,
 			}).Debug("could not find volumes for pod in host path")
 		}
 	}


### PR DESCRIPTION
This change is to implement fix for [OADP-5033](https://issues.redhat.com//browse/OADP-5033).

Blocks: https://github.com/openshift/oadp-operator/pull/1660

It is cherry picked from upstream PR and will need to be removed once upstream change is merged.
Referenced upstream bugs:

  1. https://github.com/vmware-tanzu/velero/issues/8185
  2. https://github.com/vmware-tanzu/velero/issues/8649
