### PR TITLE
OADP-5952: downstream only, update error message disableFsBackup

### DIFF
--- a/pkg/exposer/host_path.go
+++ b/pkg/exposer/host_path.go
@@ -62,9 +62,9 @@ func GetPodVolumeHostPath(ctx context.Context, pod *corev1.Pod, volumeName strin
 
 	path, err := singlePathMatch(pathGlob, fs, logger)
 	if err != nil {
-		return datapath.AccessPoint{}, errors.Wrapf(err, `error identifying unique volume path 
-    on host for volume %s in pod %s, or the DPA spec.configuration.velero.disableFsBackup 
-    is set to true, please contact your administrator. `,
+		return datapath.AccessPoint{}, errors.Wrapf(err, "error identifying unique volume path "+
+			"on host for volume %s in pod %s, or the DPA spec.configuration.velero.disableFsBackup "+
+			"is set to true, please contact your administrator. ",
 			volumeName, pod.Name)
 	}
 

--- a/pkg/exposer/host_path.go
+++ b/pkg/exposer/host_path.go
@@ -62,7 +62,10 @@ func GetPodVolumeHostPath(ctx context.Context, pod *corev1.Pod, volumeName strin
 
 	path, err := singlePathMatch(pathGlob, fs, logger)
 	if err != nil {
-		return datapath.AccessPoint{}, errors.Wrapf(err, "error identifying unique volume path on host for volume %s in pod %s", volumeName, pod.Name)
+		return datapath.AccessPoint{}, errors.Wrapf(err, `error identifying unique volume path 
+    on host for volume %s in pod %s, or the DPA spec.configuration.velero.disableFsBackup 
+    is set to true, please contact your administrator. `,
+			volumeName, pod.Name)
 	}
 
 	logger.WithField("path", path).Info("Found path matching glob")

--- a/pkg/exposer/host_path_test.go
+++ b/pkg/exposer/host_path_test.go
@@ -65,7 +65,7 @@ func TestGetPodVolumeHostPath(t *testing.T) {
 			},
 			pod: builder.ForPod(velerov1api.DefaultNamespace, "fake-pod-2").Result(),
 			pvc: "fake-pvc-1",
-			err: "error identifying unique volume path on host for volume fake-pvc-1 in pod fake-pod-2: fake-error-2",
+			err: "error identifying unique volume path on host for volume fake-pvc-1 in pod fake-pod-2, or the DPA spec.configuration.velero.disableFsBackup is set to true, please contact your administrator. : fake-error-2",
 		},
 		{
 			name: "get block volume dir success",


### PR DESCRIPTION
upstream issue:  https://github.com/vmware-tanzu/velero/issues/8185
The idea is to carry this error message d.s. only.  The fix is scheduled for velero 1.17
