### PR TITLE
Remove unused CODEGEN_VERSION from Makefile.prow

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -11,7 +11,6 @@
 # Configuration Variables
 GOFLAGS := -mod=mod
 CONGEN_VERSION := 0.16.5
-CODEGEN_VERSION := 0.22.2
 PROWBIN := /tmp/prowbin
 
 # GOPATH Setup


### PR DESCRIPTION
## Summary

Removes the unused `CODEGEN_VERSION` variable from `Makefile.prow` that was defined but never referenced.

## Details

- The `CODEGEN_VERSION := 0.22.2` variable was defined on line 14 of `Makefile.prow`
- After searching the entire repository, this variable is not used anywhere
- Removing it cleans up the Makefile and eliminates the unused variable

## Testing

- Verified the Makefile syntax is still valid after the change using `make --dry-run`
- Confirmed no other references to `CODEGEN_VERSION` exist in the repository

Fixes #363