### PR TITLE
[oadp-1.5] Update go mod after velero rebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -196,4 +196,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
-replace github.com/kopia/kopia => github.com/project-velero/kopia v0.0.0-20250227051353-20bfabbfc7a0
+replace github.com/kopia/kopia => github.com/migtools/kopia v0.0.0-20250227051353-20bfabbfc7a0

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/migtools/kopia v0.0.0-20250227051353-20bfabbfc7a0 h1:M+uk+JoJ9Rk+2e47PkxrPxIZ/z/jDnPUeHGroVJJVgs=
+github.com/migtools/kopia v0.0.0-20250227051353-20bfabbfc7a0/go.mod h1:/HYpuL787Xbqz9zjo9WcPKbPBVKvfLQlB9Qnr8AQXn0=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.84 h1:D1HVmAF8JF8Bpi6IU4V9vIEj+8pc+xU88EWMs2yed0E=
@@ -607,8 +609,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/project-velero/kopia v0.0.0-20250227051353-20bfabbfc7a0 h1:yrFIqNlajYzR0pmHPWUNqBg4qg2GMnj7tvZXNjdPdYI=
-github.com/project-velero/kopia v0.0.0-20250227051353-20bfabbfc7a0/go.mod h1:/HYpuL787Xbqz9zjo9WcPKbPBVKvfLQlB9Qnr8AQXn0=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=


### PR DESCRIPTION
[oadp-1.5] Update go mod after velero rebase
Updated go.mod after velero rebase to point to migtools/kopia branch oadp-1.5