### PR TITLE
Fix restic checkout in Dockerfile.ubi to get default branch

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -22,7 +22,7 @@ ENV GOPATH=$APP_ROOT
 
 RUN mkdir -p $APP_ROOT/src/github.com/restic \
     && cd $APP_ROOT/src/github.com/restic \
-    && git clone https://github.com/konveyor/restic -b konveyor-dev
+    && git clone https://github.com/openshift/restic 
 
 WORKDIR $APP_ROOT/src/github.com/restic/restic
 


### PR DESCRIPTION
After switch to oadp-dev, just use default branch for restic checkout instead of konveyor-dev.
