### PR TITLE
fix backup repo connect

### DIFF
--- a/Root Cause Analysis and Fix Proposal
+++ b/Root Cause Analysis and Fix Proposal
@@ -1,0 +1,94 @@
+Root Cause Analysis and Fix Proposal
+I've completed the investigation into the HCP test BackupRepository Kopia initialization failure. Here are my findings:
+Root Cause
+The error occurs in Velero's PrepareRepo function at pkg/repository/provider/unified_repo.go:170-215:
+func (urp *unifiedRepoProvider) PrepareRepo(ctx context.Context, param RepoParam) error {
+    // ... setup code ...
+    
+    repoOption, err := udmrepo.NewRepoOptions(
+        udmrepo.WithPassword(urp, param),
+        udmrepo.WithConfigFile(urp.workPath, string(param.BackupRepo.UID)),
+        // ... other options ...
+    )
+    
+    // Check if repo exists in backend storage
+    if created, err := urp.repoService.IsCreated(ctx, *repoOption); err != nil {
+        return errors.Wrap(err, "error to check backup repo")
+    } else if created {
+        log.Debug("Repo has already been initialized remotely")
+        return nil  // ❌ BUG: Returns without creating local config file!
+    }
+    
+    // Only reached if repo doesn't exist in backend
+    err = urp.repoService.Create(ctx, *repoOption)
+    // ...
+}
+The Problem:
+Kopia Architecture: Kopia repositories have two components:
+Backend storage (S3/Azure/GCS) containing repository metadata
+Local config file (/home/velero/udmrepo/repo-<uid>.conf) containing connection info
+Current Flow:
+repo.Initialize(): Creates backend storage metadata AND creates initial local config file
+repo.Connect(): Connects to existing backend AND creates/updates local config file
+repo.Open(): Opens repo using EXISTING local config file
+The Bug:
+When PrepareRepo finds the repository already exists in backend storage (via IsCreated()), it returns immediately without calling Connect()
+This means the local config file is never created/recreated
+Since the config file is stored in ephemeral pod storage (/home/velero), it's lost when:
+  - A different node-agent pod tries to use the repository
+  - The pod restarts
+  - The creating pod is deleted
+Later, when DataUpload tries to open the repository via repoService.Open(), it fails because the config file doesn't exist
+When This Occurs
+This bug manifests in these scenarios:
+Multi-pod environments: One node-agent pod creates the BackupRepository, another pod tries to use it
+Pod restarts: After the creating pod restarts, it loses the local config file (ephemeral storage)
+HCP tests: Multiple backups in sequence where different resources trigger repository initialization
+The Fix
+The fix is to ensure PrepareRepo always calls Connect() when the repository exists remotely:
+func (urp *unifiedRepoProvider) PrepareRepo(ctx context.Context, param RepoParam) error {
+    // ... setup code ...
+    
+    repoOption, err := udmrepo.NewRepoOptions(/* ... */)
+    if err != nil {
+        return errors.Wrap(err, "error to get repo options")
+    }
+
+    if created, err := urp.repoService.IsCreated(ctx, *repoOption); err != nil {
+        return errors.Wrap(err, "error to check backup repo")
+    } else if created {
+        log.Debug("Repo has already been initialized remotely, connecting to it")
+        // ✅ FIX: Call Connect to create local config file
+        return urp.repoService.Connect(ctx, *repoOption)
+    }
+
+    // Repository doesn't exist, create it
+    if param.BackupLocation.Spec.AccessMode == velerov1api.BackupStorageLocationAccessModeReadOnly {
+        return errors.Errorf("cannot create new backup repo for read-only backup storage location %s/%s", 
+            param.BackupLocation.Namespace, param.BackupLocation.Name)
+    }
+
+    err = urp.repoService.Create(ctx, *repoOption)
+    if err != nil {
+        return errors.Wrap(err, "error to create backup repo")
+    }
+
+    log.Debug("Prepare repo complete")
+    return nil
+}
+File to Fix
+Location: /Users/tkaovila/git/velero/pkg/repository/provider/unified_repo.go
+Lines: 211-216 (specifically line 215)
+Change: Replace `return nil` with `return urp.repoService.Connect(ctx, *repoOption)`
+Additional Context
+From lib_repo.go:98-106, Create() calls writeInitParameters() which opens the repo. This means:
+The initial repo.Initialize() does create a local config file
+However, this config file is stored in ephemeral pod storage (/home/velero/udmrepo/)
+The issue is that subsequent PrepareRepo() calls don't recreate the config file when it's missing
+
+This explains the failure pattern:
+The first DataUpload might succeed (if it runs on the same pod that created the repo)
+Subsequent DataUploads fail when:
+  - Running on different node-agent pods (don't have the config file)
+  - Running after pod restart (config file lost from ephemeral storage)
+All HCP resources fail with the same error because they're processed by pods without the config file

--- a/changelogs/unreleased/0000-kaovilai
+++ b/changelogs/unreleased/0000-kaovilai
@@ -1,0 +1,1 @@
+Fix BackupRepository PrepareRepo to ensure local config file exists when repo exists remotely, using Open() fallback to Connect() pattern. This fixes failures in multi-pod environments and after pod restarts where config files are missing or invalid.

--- a/pkg/repository/provider/unified_repo.go
+++ b/pkg/repository/provider/unified_repo.go
@@ -213,8 +213,17 @@ func (urp *unifiedRepoProvider) PrepareRepo(ctx context.Context, param RepoParam
 	if ready, err := urp.repoService.IsReady(ctx, *repoOption, readOnly); err != nil {
 		return errors.Wrap(err, "error to check backup repo")
 	} else if ready {
-		log.Info("Repo has already been initialized")
-		return nil
+		bkRepo, err := urp.repoService.Open(ctx, *repoOption)
+		if err == nil {
+			if c := bkRepo.Close(ctx); c != nil {
+				log.WithError(c).Error("Failed to close repo")
+			}
+			log.Debug("Repo has already been initialized remotely and config file is valid")
+			return nil
+		}
+
+		log.WithError(err).Debug("Repo exists remotely but config file issue detected, connecting to it")
+		return urp.repoService.Connect(ctx, *repoOption)
 	}
 
 	if readOnly {

--- a/pkg/repository/provider/unified_repo_test.go
+++ b/pkg/repository/provider/unified_repo_test.go
@@ -612,8 +612,11 @@ func TestPrepareRepo(t *testing.T) {
 		funcTable       localFuncTable
 		getter          *credmock.SecretStore
 		repoService     *reposervicenmocks.BackupRepoService
+		backupRepo      *reposervicenmocks.BackupRepo
 		retFuncCreate   func(context.Context, udmrepo.RepoOptions) error
 		retFuncCheck    func(context.Context, udmrepo.RepoOptions, bool) (bool, error)
+		retFuncConnect  func(context.Context, udmrepo.RepoOptions) error
+		retFuncOpen     []any
 		credStoreReturn string
 		credStoreError  error
 		readOnlyBSL     bool
@@ -662,7 +665,7 @@ func TestPrepareRepo(t *testing.T) {
 			expectedErr: "error to check backup repo: fake-error",
 		},
 		{
-			name:            "already initialized",
+			name:            "already initialized with valid config",
 			getter:          new(credmock.SecretStore),
 			credStoreReturn: "fake-password",
 			funcTable: localFuncTable{
@@ -674,12 +677,65 @@ func TestPrepareRepo(t *testing.T) {
 				},
 			},
 			repoService: new(reposervicenmocks.BackupRepoService),
+			backupRepo:  new(reposervicenmocks.BackupRepo),
 			retFuncCheck: func(ctx context.Context, repoOption udmrepo.RepoOptions, readOnly bool) (bool, error) {
 				return true, nil
 			},
+			retFuncOpen: []any{nil}, // Open succeeds - config file exists and is valid
 			retFuncCreate: func(ctx context.Context, repoOption udmrepo.RepoOptions) error {
-				return errors.New("fake-error")
+				return errors.New("fake-error-should-not-be-called")
 			},
+		},
+		{
+			name:            "already initialized but config missing and connect succeeds",
+			getter:          new(credmock.SecretStore),
+			credStoreReturn: "fake-password",
+			funcTable: localFuncTable{
+				getStorageVariables: func(*velerov1api.BackupStorageLocation, string, string, map[string]string, velerocredentials.CredentialGetter) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+				getStorageCredentials: func(*velerov1api.BackupStorageLocation, velerocredentials.FileStore) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+			},
+			repoService: new(reposervicenmocks.BackupRepoService),
+			backupRepo:  new(reposervicenmocks.BackupRepo),
+			retFuncCheck: func(ctx context.Context, repoOption udmrepo.RepoOptions, readOnly bool) (bool, error) {
+				return true, nil
+			},
+			retFuncOpen: []any{errors.New("fake-open-error")}, // Open fails - config file missing/invalid
+			retFuncConnect: func(ctx context.Context, repoOption udmrepo.RepoOptions) error {
+				return nil // Connect succeeds - recreates config file
+			},
+			retFuncCreate: func(ctx context.Context, repoOption udmrepo.RepoOptions) error {
+				return errors.New("fake-error-should-not-be-called")
+			},
+		},
+		{
+			name:            "already initialized but config missing and connect fails",
+			getter:          new(credmock.SecretStore),
+			credStoreReturn: "fake-password",
+			funcTable: localFuncTable{
+				getStorageVariables: func(*velerov1api.BackupStorageLocation, string, string, map[string]string, velerocredentials.CredentialGetter) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+				getStorageCredentials: func(*velerov1api.BackupStorageLocation, velerocredentials.FileStore) (map[string]string, error) {
+					return map[string]string{}, nil
+				},
+			},
+			repoService: new(reposervicenmocks.BackupRepoService),
+			backupRepo:  new(reposervicenmocks.BackupRepo),
+			retFuncCheck: func(ctx context.Context, repoOption udmrepo.RepoOptions, readOnly bool) (bool, error) {
+				return true, nil
+			},
+			retFuncOpen: []any{errors.New("fake-open-error")}, // Open fails - config file missing/invalid
+			retFuncConnect: func(ctx context.Context, repoOption udmrepo.RepoOptions) error {
+				return errors.New("fake-connect-error") // Connect also fails
+			},
+			retFuncCreate: func(ctx context.Context, repoOption udmrepo.RepoOptions) error {
+				return errors.New("fake-error-should-not-be-called")
+			},
+			expectedErr: "fake-connect-error",
 		},
 		{
 			name:            "bsl is readonly",
@@ -787,6 +843,21 @@ func TestPrepareRepo(t *testing.T) {
 
 			tc.repoService.On("IsReady", mock.Anything, mock.Anything, mock.Anything).Return(tc.retFuncCheck)
 			tc.repoService.On("Create", mock.Anything, mock.Anything, mock.Anything).Return(tc.retFuncCreate)
+			tc.repoService.On("Connect", mock.Anything, mock.Anything).Return(tc.retFuncConnect)
+
+			// Mock Open() - returns BackupRepo if successful, error if not
+			if tc.retFuncOpen != nil {
+				if tc.retFuncOpen[0] == nil {
+					// Open succeeds - return the mock BackupRepo
+					if tc.backupRepo != nil {
+						tc.backupRepo.On("Close", mock.Anything).Return(nil)
+					}
+					tc.repoService.On("Open", mock.Anything, mock.Anything).Return(tc.backupRepo, nil)
+				} else {
+					// Open fails - return error
+					tc.repoService.On("Open", mock.Anything, mock.Anything).Return(nil, tc.retFuncOpen[0])
+				}
+			}
 
 			if tc.readOnlyBSL {
 				bsl.Spec.AccessMode = velerov1api.BackupStorageLocationAccessModeReadOnly

--- a/velero-preparerepo-bug.md
+++ b/velero-preparerepo-bug.md
@@ -1,0 +1,103 @@
+# Velero PrepareRepo Bug: Missing Local Kopia Config File
+
+## Summary
+
+The `PrepareRepo()` function in Velero's unified repository provider fails to create the local Kopia configuration file when connecting to an existing remote repository. This causes subsequent backup operations to fail with "config file not found" errors in multi-pod environments, after pod restarts, or during sequential backup operations.
+
+## Bug Location
+
+**File**: `pkg/repository/provider/unified_repo.go`
+**Lines**: 196-200
+**Velero Version**: Current main branch (observed in OpenShift OADP operator using Velero)
+
+## Root Cause
+
+When `PrepareRepo()` detects that a repository already exists remotely (via `IsCreated()`), it returns immediately without calling `Connect()`:
+
+```go
+if created, err := urp.repoService.IsCreated(ctx, *repoOption); err != nil {
+    return errors.Wrap(err, "error to check backup repo")
+} else if created {
+    log.Debug("Repo has already been initialized remotely")
+    return nil  // ❌ BUG: Returns without creating local config file!
+}
+```
+
+**Problem**: The `Connect()` function is responsible for creating the local Kopia config file (e.g., `/home/velero/udmrepo/repo-<uid>.conf`). Skipping this call means the config file is never created, causing later `Open()` operations to fail.
+
+## Kopia Architecture Context
+
+Kopia requires **two components** to function:
+1. **Backend Storage**: Repository metadata stored in S3/Azure/GCS (created by `Create()`)
+2. **Local Config File**: Connection information stored locally (created by `Connect()`)
+
+The current code only creates the local config file during initial repository creation, not when connecting to existing repositories.
+
+## Reproduction Scenarios
+
+1. **Multi-node environments (node-agent daemonset)**:
+   - Node-agent pod on Node A creates the repository (config file exists only on Node A's pod)
+   - Node-agent pod on Node B tries to use the same repository for a different PVC/backup
+   - Result: Node B's node-agent pod fails with "config file not found"
+
+2. **Node-agent pod restarts**:
+   - Node-agent pod creates repository with config in ephemeral storage (`/home/velero/udmrepo/`)
+   - Node-agent pod restarts (upgrade, crash, node drain), losing the config file
+   - Next backup attempt by the restarted node-agent fails
+
+3. **Sequential backups across nodes (node-agent daemonset)**:
+   - First backup creates repository via node-agent pod on Node A
+   - Second backup of a PVC on Node B is handled by that node's node-agent pod
+   - Node B's node-agent pod can't access the repository (no local config file)
+
+## Error Message
+
+```
+error to initialize data path: error to boost backup repository connection:
+error to connect backup repo: error to connect repo with storage:
+error to connect to repository: error loading config file:
+open /home/velero/udmrepo/repo-<uuid>.conf: no such file or directory
+```
+
+## Proposed Fix
+
+Replace the early return with a `Connect()` call:
+
+```go
+if created, err := urp.repoService.IsCreated(ctx, *repoOption); err != nil {
+    return errors.Wrap(err, "error to check backup repo")
+} else if created {
+    log.Debug("Repo has already been initialized remotely, connecting to it")
+    return urp.repoService.Connect(ctx, *repoOption)  // ✅ FIX
+}
+```
+
+## Impact
+
+**Severity**: High
+**Affected Scenarios**:
+- Multi-node Kubernetes clusters
+- Any environment with pod restarts
+- Sequential backup operations
+- CSI Data Mover backups in OADP/OpenShift
+
+**Current Workaround**: None known. The issue manifests as intermittent backup failures.
+
+## Testing
+
+The bug was discovered while investigating HCP (Hosted Control Plane) backup test failures in OpenShift OADP operator:
+- **PR**: openshift/oadp-operator#2013
+- **Test**: HCP backup/restore with CSI Data Mover
+- **Build Log**: [CI Build Log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_oadp-operator/2013/pull-ci-openshift-oadp-operator-oadp-dev-4.20-e2e-test-hcp-aws/1986610135258107904/artifacts/e2e-test-hcp-aws/e2e/build-log.txt)
+
+## Related Code
+
+- `pkg/repository/udmrepo/kopialib/repo_init.go`: `ConnectBackupRepo()` creates local config
+- `pkg/repository/udmrepo/kopialib/lib_repo.go`: `Open()` requires existing config file
+- `pkg/repository/provider/unified_repo.go`: `PrepareRepo()` contains the bug
+
+## Status
+
+- **Discovered**: 2025-11-07
+- **Velero Issue Tracker**: No existing issues found matching this bug
+- **Fix Status**: Proposed but not yet submitted


### PR DESCRIPTION
- **Add design doc**
- **Update design**
- **New design doc**
- **Enhance wildcard namespace support in backup and restore design document**
- **Refine wildcard namespace support design document**
- **Enhance wildcard namespace support design document**
- **Update design**
- **Status fields are part of a struct**
- **Added struct change**
- **Updates**
- **update**
- **Leaner design**
- **Simplify**
- **repo provider interface refactor for repo static configuration**
- **Fix PrepareRepo to ensure local config file is created when repository exists remotely, addressing failures in multi-pod environments and after pod restarts.**

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository preparation to ensure local configuration files are properly established when remote repositories already exist, addressing failures in multi-pod environments and pod restart scenarios.

* **Tests**
  * Expanded test coverage for repository configuration validation and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->