### PR TITLE
feat: Add FIPS 140-3 support with GOFIPS140 v1.26.0

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -1,9 +1,19 @@
+# FIPS 140-3 Compliance Configuration:
+# - GOFIPS140=v1.26.0: Embeds Go's native FIPS 140-3 cryptographic module (certified A6650)
+# - GODEBUG=fips140=on: Enables FIPS mode at runtime by default
+# - CGO_ENABLED=0: GOFIPS140 is pure Go, no CGO/OpenSSL dependencies required
+#   (see https://go.dev/blog/fips140 - "written in pure Go (and Go assembly)")
+# - Cross-compilation supported natively (no QEMU needed for multi-arch builds)
+# - Required for OpenShift deployments in regulated environments (gov, healthcare, finance)
+# - Containers sometimes consumed without OADP operator, so FIPS must be enabled by default
+
 FROM --platform=$BUILDPLATFORM quay.io/konveyor/builder:ubi9-latest AS builder
 ARG BUILDPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
 
 ENV GOPATH=$APP_ROOT
+ENV GOFIPS140=v1.26.0
 
 COPY . /go/src/github.com/vmware-tanzu/velero
 
@@ -40,5 +50,6 @@ RUN chmod -R 777 /home/velero
 
 USER 65534:65534
 ENV HOME=/home/velero
+ENV GODEBUG=fips140=on
 
 ENTRYPOINT ["/velero"]


### PR DESCRIPTION
## Summary

Add native Go FIPS 140-3 cryptographic module support to Velero for OpenShift OADP 1.5.

## Changes

- Add `GOFIPS140=v1.26.0` build environment variable
- Add `GODEBUG=fips140=on` runtime environment variable
- Keep `CGO_ENABLED=0` (GOFIPS140 is pure Go, no CGO needed)
- Add inline documentation explaining FIPS configuration

## Why FIPS by Default?

This PR enables FIPS mode by default (`GODEBUG=fips140=on`) because:

1. **No OADP Operator**: Containers sometimes consumed without OADP operator involvement
2. **Container Must Be FIPS-Ready**: FIPS must be enabled by default in the image itself
3. **Target Environment**: OADP 1.5 is specifically for regulated OpenShift deployments requiring FIPS compliance
4. **Secure by Default**: Follows security best practices for regulated environments

## FIPS Implementation Details

Uses Go's **native FIPS 140-3 module** (different from the [OpenSSL-based golang-fips approach](https://github.com/golang-fips/go)):

- ✅ Official FIPS 140-3 certified (module A6650)
- ✅ **Pure Go implementation** - no CGO or OpenSSL dependencies
- ✅ Cross-compilation works natively (no QEMU or architecture-specific C compilers needed)
- ✅ No runtime OpenSSL dependencies
- ✅ Supports all major platforms (Linux x86-64, ARM64, etc)

## Why CGO_ENABLED=0?

Per the [official Go FIPS blog](https://go.dev/blog/fips140):

> "The FIPS 140-3 compliant cryptographic module is written in pure Go (and Go assembly) rather than using cgo or syscalls to call into third-party libraries"

This means:
- No C compiler needed at build time
- Simpler cross-compilation (just set GOOS/GOARCH)
- No dynamic linking to system OpenSSL libraries
- Better performance (no CGO call overhead)

## Related

- Companion PR for velero-plugin-for-microsoft-azure: openshift/velero-plugin-for-microsoft-azure#124
- Reference implementation: openshift/hypershift-oadp-plugin#236

## Testing

Build and verify FIPS mode:
```bash
podman build -f Dockerfile.ubi -t velero:fips-test .
podman run --rm velero:fips-test /velero version
# Verify GODEBUG env is set
podman run --rm velero:fips-test env | grep GODEBUG
```

Runtime verification in cluster:
```bash
# Deploy with OADP 1.5
# Check Velero pod logs for FIPS mode activation
oc logs -n openshift-adp deployment/velero | grep -i fips
```

> [!Note]
> Responses generated with Claude

/cc @kaovilai