### PR TITLE
OADP-1.6: Fix CSI snapshot rate limiter context deadline errors

### DIFF
--- a/pkg/util/csi/volume_snapshot.go
+++ b/pkg/util/csi/volume_snapshot.go
@@ -669,20 +669,44 @@ func WaitUntilVSCHandleIsReady(
 		// The short interval for the first ten seconds is due to the fact that
 		// Microsoft VSS backups have a hard-coded unfreeze call after 10 seconds,
 		// so we need to minimize waiting time during the first 10 seconds.
-		// First poll with a short interval and timeout.
 		interval = 1 * time.Second
-		timeout := 10 * time.Second
-		err = wait.PollUntilContextTimeout(
-			context.Background(),
+		pollTimeout := 10 * time.Second
+
+		// Create context with extended timeout for rate limiter waits.
+		// This prevents "rate: Wait(n=1) would exceed context deadline" errors
+		// when the client rate limiter needs to wait for tokens during high API load.
+		ctx, cancel := context.WithTimeout(context.Background(), pollTimeout+30*time.Second)
+		defer cancel()
+
+		// Track polling start time to enforce the 10-second limit
+		startTime := time.Now()
+		timeoutExceeded := false
+
+		// Wrap pollFunc to enforce time-based timeout while allowing extended context for rate limiter
+		wrappedPollFunc := func(ctx context.Context) (bool, error) {
+			// Check if we've exceeded the 10-second polling timeout
+			if time.Since(startTime) > pollTimeout {
+				if !timeoutExceeded {
+					timeoutExceeded = true
+					log.Debugf("Polling timeout exceeded after %v, stopping early frequent polling", time.Since(startTime))
+				}
+				return false, wait.ErrorInterrupted(errors.New("early frequent polling timeout exceeded"))
+			}
+			// Call the original pollFunc
+			return pollFunc(ctx)
+		}
+
+		err = wait.PollUntilContextCancel(
+			ctx,
 			interval,
-			timeout,
 			true,
-			pollFunc,
+			wrappedPollFunc,
 		)
 
 		if err == nil {
 			return vsc, nil
 		}
+		// Treat interrupted waits as expected (continue to fallback polling)
 		if !wait.Interrupted(err) {
 			return nil, err
 		}


### PR DESCRIPTION
After PR #9629 introduced early frequent polling for CSI snapshots, users are experiencing 'client rate limiter Wait would exceed context deadline' errors.

This occurs on fresh clusters with high API load (e.g., Azure AKS initialization).

Root Cause: Context deadline too short to accommodate rate limiter token waits.

Solution: Extend context timeout while enforcing time-based polling limit via wrapped pollFunc. Maintains exact polling behavior while preventing spurious failures.

Thank you for contributing to Velero!

# Please add a summary of your change

# Does your change fix a particular issue?

Fixes #(issue)

# Please indicate you've done the following:

- [ ] [Accepted the DCO](https://velero.io/docs/v1.5/code-standards/#dco-sign-off). Commits without the DCO will delay acceptance.
- [ ] [Created a changelog file (`make new-changelog`)](https://velero.io/docs/main/code-standards/#adding-a-changelog) or comment `/kind changelog-not-required` on this PR.
- [ ] Updated the corresponding documentation in `site/content/docs/main`.
