### PR TITLE
Fix golangci-lint version extraction for go install format

### DIFF
--- a/Makefile.prow
+++ b/Makefile.prow
@@ -92,9 +92,15 @@ $(GOBIN)/controller-gen:
 
 $(GOBIN)/golangci-lint:
 	@echo "Extracting golangci-lint version from hack/build-image/Dockerfile"
-	GOLANGCI_VERSION=$$(grep -oP 'golangci-lint/(master|HEAD)/install.sh.*\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile); \
+	GOLANGCI_VERSION=$$(grep -oP 'golangci-lint/(master|HEAD)/install.sh.*\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile || \
+		grep -oP 'golangci-lint(/v[0-9]+)?/cmd/golangci-lint@\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile); \
 	echo "Installing golangci-lint version: $$GOLANGCI_VERSION"; \
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $$GOLANGCI_VERSION
+	MAJOR=$$(echo "$$GOLANGCI_VERSION" | grep -oP '^v\K[0-9]+'); \
+	if [ "$$MAJOR" -ge 2 ]; then \
+		go install github.com/golangci/golangci-lint/v$$MAJOR/cmd/golangci-lint@$$GOLANGCI_VERSION; \
+	else \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) $$GOLANGCI_VERSION; \
+	fi
 
 $(GOBIN)/setup-envtest:
 	@echo "Installing envtest tools"

--- a/Makefile.prow
+++ b/Makefile.prow
@@ -94,6 +94,10 @@ $(GOBIN)/golangci-lint:
 	@echo "Extracting golangci-lint version from hack/build-image/Dockerfile"
 	GOLANGCI_VERSION=$$(grep -oP 'golangci-lint/(master|HEAD)/install.sh.*\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile || \
 		grep -oP 'golangci-lint(/v[0-9]+)?/cmd/golangci-lint@\Kv[0-9]+\.[0-9]+\.[0-9]+' hack/build-image/Dockerfile); \
+	if [ -z "$$GOLANGCI_VERSION" ]; then \
+		echo "Failed to extract golangci-lint version from hack/build-image/Dockerfile"; \
+		exit 1; \
+	fi; \
 	echo "Installing golangci-lint version: $$GOLANGCI_VERSION"; \
 	MAJOR=$$(echo "$$GOLANGCI_VERSION" | grep -oP '^v\K[0-9]+'); \
 	if [ "$$MAJOR" -ge 2 ]; then \


### PR DESCRIPTION
## Summary

Upstream velero switched golangci-lint installation in `hack/build-image/Dockerfile` from the curl-based installer (`curl ... install.sh | sh -s -- vX.Y.Z`) to `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@vX.Y.Z`. The downstream `Makefile.prow` grep regex only matched the old format, so version extraction returned empty, causing CI lint failures with a checksum mismatch.

This updates the version extraction to handle both formats and uses `go install` for v2+.

Closes #519

## Test plan

- [ ] Verify the grep matches the current `oadp-dev` Dockerfile format (`curl | sh`)
- [ ] Verify the grep matches the `v1.18.2-rc.2` Dockerfile format (`go install`)
- [ ] Cherry-pick to `oadp-1.6` after merge and verify lint CI passes on rebase PR #518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the linting tool setup to automatically detect and install the intended linter version.
  * Added smarter handling for different major versions to ensure installation works consistently across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->