### PR TITLE
UPSTREAM: <carry>: fix context leak in backupper_test.go

### DIFF
--- a/pkg/podvolume/backupper_test.go
+++ b/pkg/podvolume/backupper_test.go
@@ -570,7 +570,8 @@ func (l *logHook) Fire(entry *logrus.Entry) error {
 }
 
 func TestWaitAllPodVolumesProcessed(t *testing.T) {
-	timeoutCtx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
 	cases := []struct {
 		name              string
 		ctx               context.Context


### PR DESCRIPTION
## Summary
- Capture and defer the cancel function returned by `context.WithTimeout` in `TestWaitAllPodVolumesProcessed` to fix a `go vet` failure blocking the OADP rebase pipeline.

## Test plan
- [x] Verified `go vet ./pkg/podvolume/...` fails without the fix
- [x] Verified `go vet ./pkg/podvolume/...` passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)