### PR TITLE
Fix gofmt alignment and missing blob.Storage mock methods

### DIFF
--- a/pkg/repository/udmrepo/kopialib/backend/common.go
+++ b/pkg/repository/udmrepo/kopialib/backend/common.go
@@ -69,9 +69,9 @@ func SetupNewRepositoryOptions(ctx context.Context, flags map[string]string) rep
 func SetupConnectOptions(ctx context.Context, repoOptions udmrepo.RepoOptions) repo.ConnectOptions {
 	return repo.ConnectOptions{
 		CachingOptions: content.CachingOptions{
-			ContentCacheSizeBytes:         maxDataCacheMB << 20,
+			ContentCacheSizeBytes:  maxDataCacheMB << 20,
 			MetadataCacheSizeBytes: maxMetadataCacheMB << 20,
-			MaxListCacheDuration:      content.DurationSeconds(time.Duration(maxCacheDurationSecond) * time.Second),
+			MaxListCacheDuration:   content.DurationSeconds(time.Duration(maxCacheDurationSecond) * time.Second),
 		},
 		ClientOptions: repo.ClientOptions{
 			Hostname:    optionalHaveString(udmrepo.GenOptionOwnerDomain, repoOptions.GeneralOptions),

--- a/pkg/repository/udmrepo/kopialib/backend/common_test.go
+++ b/pkg/repository/udmrepo/kopialib/backend/common_test.go
@@ -111,9 +111,9 @@ func TestSetupNewRepositoryOptions(t *testing.T) {
 
 func TestSetupConnectOptions(t *testing.T) {
 	defaultCacheOption := content.CachingOptions{
-		ContentCacheSizeBytes:         2000 << 20,
+		ContentCacheSizeBytes:  2000 << 20,
 		MetadataCacheSizeBytes: 2000 << 20,
-		MaxListCacheDuration:      content.DurationSeconds(time.Duration(30) * time.Second),
+		MaxListCacheDuration:   content.DurationSeconds(time.Duration(30) * time.Second),
 	}
 
 	testCases := []struct {

--- a/pkg/repository/udmrepo/kopialib/backend/mocks/Storage.go
+++ b/pkg/repository/udmrepo/kopialib/backend/mocks/Storage.go
@@ -57,6 +57,20 @@ func (_m *Storage) DeleteBlob(ctx context.Context, blobID blob.ID) error {
 	return r0
 }
 
+// ExtendBlobRetention provides a mock function with given fields: ctx, blobID, opts
+func (_m *Storage) ExtendBlobRetention(ctx context.Context, blobID blob.ID, opts blob.ExtendOptions) error {
+	ret := _m.Called(ctx, blobID, opts)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, blob.ID, blob.ExtendOptions) error); ok {
+		r0 = rf(ctx, blobID, opts)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DisplayName provides a mock function with given fields:
 func (_m *Storage) DisplayName() string {
 	ret := _m.Called()
@@ -80,6 +94,20 @@ func (_m *Storage) FlushCaches(ctx context.Context) error {
 		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// IsReadOnly provides a mock function with given fields:
+func (_m *Storage) IsReadOnly() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0


### PR DESCRIPTION
## Summary

Two fixes for unit test failures on oadp-1.3:

1. **gofmt alignment** — CachingOptions struct fields in `common.go` and `common_test.go` were manually padded after the kopia field renames in c77a5530, but the alignment didn't match `gofmt` canonical formatting, causing `make verify` to fail.

2. **Missing mock methods** — The migtools/kopia fork added `ExtendBlobRetention` and `IsReadOnly` to the `blob.Storage` interface, but the `Storage` mock was not regenerated, causing `TestCreateBackupRepo/storage_connect_fail` to panic on a failed interface assertion (Go's nil-pointer-in-interface gotcha).

## Test plan

- [ ] `pull-ci-openshift-velero-oadp-1.3-unit-test` passes