### PR TITLE
UPSTREAM: <carry>: Fix non-constant format strings flagged by go vet

### DIFF
--- a/pkg/datamover/backup_micro_service.go
+++ b/pkg/datamover/backup_micro_service.go
@@ -19,6 +19,7 @@ package datamover
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -205,7 +206,7 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 	}
 
 	log.Info("Async fs backup data path started")
-	r.eventRecorder.Event(du, false, datapath.EventReasonStarted, "Data path for %s started", du.Name)
+	r.eventRecorder.Event(du, false, datapath.EventReasonStarted, fmt.Sprintf("Data path for %s started", du.Name))
 
 	result := ""
 	select {
@@ -222,7 +223,7 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 		log.WithError(err).Error("Async fs backup was not completed")
 	}
 
-	r.eventRecorder.EndingEvent(du, false, datapath.EventReasonStopped, "Data path for %s stopped", du.Name)
+	r.eventRecorder.EndingEvent(du, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s stopped", du.Name))
 
 	return result, err
 }
@@ -263,7 +264,7 @@ func (r *BackupMicroService) OnDataUploadFailed(ctx context.Context, namespace s
 	log := r.logger.WithField("dataupload", duName)
 	log.WithError(err).Error("Async fs backup data path failed")
 
-	r.eventRecorder.Event(r.dataUpload, false, datapath.EventReasonFailed, "Data path for data upload %s failed, error %v", r.dataUploadName, err)
+	r.eventRecorder.Event(r.dataUpload, false, datapath.EventReasonFailed, fmt.Sprintf("Data path for data upload %s failed, error %v", r.dataUploadName, err))
 	r.resultSignal <- dataPathResult{
 		err: errors.Wrapf(err, "Data path for data upload %s failed", r.dataUploadName),
 	}
@@ -273,7 +274,7 @@ func (r *BackupMicroService) OnDataUploadCancelled(ctx context.Context, namespac
 	log := r.logger.WithField("dataupload", duName)
 	log.Warn("Async fs backup data path canceled")
 
-	r.eventRecorder.Event(r.dataUpload, false, datapath.EventReasonCancelled, "Data path for data upload %s canceled", duName)
+	r.eventRecorder.Event(r.dataUpload, false, datapath.EventReasonCancelled, fmt.Sprintf("Data path for data upload %s canceled", duName))
 	r.resultSignal <- dataPathResult{
 		err: errors.New(datapath.ErrCancelled),
 	}
@@ -305,12 +306,12 @@ func (r *BackupMicroService) closeDataPath(ctx context.Context, duName string) {
 func (r *BackupMicroService) cancelDataUpload(du *velerov2alpha1api.DataUpload) {
 	r.logger.WithField("DataUpload", du.Name).Info("Data upload is being canceled")
 
-	r.eventRecorder.Event(du, false, datapath.EventReasonCancelling, "Canceling for data upload %s", du.Name)
+	r.eventRecorder.Event(du, false, datapath.EventReasonCancelling, fmt.Sprintf("Canceling for data upload %s", du.Name))
 
 	fsBackup := r.dataPathMgr.GetAsyncBR(du.Name)
 	if fsBackup == nil {
 		r.OnDataUploadCancelled(r.ctx, du.GetNamespace(), du.GetName())
-		r.eventRecorder.EndingEvent(du, false, datapath.EventReasonStopped, "Data path for %s exited without start", du.Name)
+		r.eventRecorder.EndingEvent(du, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s exited without start", du.Name))
 	} else {
 		fsBackup.Cancel()
 	}

--- a/pkg/datamover/backup_micro_service_test.go
+++ b/pkg/datamover/backup_micro_service_test.go
@@ -55,22 +55,22 @@ type backupMsTestHelper struct {
 	eventLock    sync.Mutex
 }
 
-func (bt *backupMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (bt *backupMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string) {
 	bt.eventLock.Lock()
 	defer bt.eventLock.Unlock()
 
 	bt.withEvent = true
 	bt.eventReason = reason
-	bt.eventMsg = fmt.Sprintf(message, a...)
+	bt.eventMsg = message
 }
 
-func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string) {
 	bt.eventLock.Lock()
 	defer bt.eventLock.Unlock()
 
 	bt.withEvent = true
 	bt.eventReason = reason
-	bt.eventMsg = fmt.Sprintf(message, a...)
+	bt.eventMsg = message
 }
 func (bt *backupMsTestHelper) Shutdown() {}
 

--- a/pkg/datamover/restore_micro_service.go
+++ b/pkg/datamover/restore_micro_service.go
@@ -18,6 +18,7 @@ package datamover
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -185,7 +186,7 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 	}
 
 	log.Info("Async fs restore data path started")
-	r.eventRecorder.Event(dd, false, datapath.EventReasonStarted, "Data path for %s started", dd.Name)
+	r.eventRecorder.Event(dd, false, datapath.EventReasonStarted, fmt.Sprintf("Data path for %s started", dd.Name))
 
 	result := ""
 	select {
@@ -202,7 +203,7 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 		log.WithError(err).Error("Async fs restore was not completed")
 	}
 
-	r.eventRecorder.EndingEvent(dd, false, datapath.EventReasonStopped, "Data path for %s stopped", dd.Name)
+	r.eventRecorder.EndingEvent(dd, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s stopped", dd.Name))
 
 	return result, err
 }
@@ -241,7 +242,7 @@ func (r *RestoreMicroService) OnDataDownloadFailed(ctx context.Context, namespac
 	log := r.logger.WithField("datadownload", ddName)
 	log.WithError(err).Error("Async fs restore data path failed")
 
-	r.eventRecorder.Event(r.dataDownload, false, datapath.EventReasonFailed, "Data path for data download %s failed, error %v", r.dataDownloadName, err)
+	r.eventRecorder.Event(r.dataDownload, false, datapath.EventReasonFailed, fmt.Sprintf("Data path for data download %s failed, error %v", r.dataDownloadName, err))
 	r.resultSignal <- dataPathResult{
 		err: errors.Wrapf(err, "Data path for data download %s failed", r.dataDownloadName),
 	}
@@ -251,7 +252,7 @@ func (r *RestoreMicroService) OnDataDownloadCancelled(ctx context.Context, names
 	log := r.logger.WithField("datadownload", ddName)
 	log.Warn("Async fs restore data path canceled")
 
-	r.eventRecorder.Event(r.dataDownload, false, datapath.EventReasonCancelled, "Data path for data download %s canceled", ddName)
+	r.eventRecorder.Event(r.dataDownload, false, datapath.EventReasonCancelled, fmt.Sprintf("Data path for data download %s canceled", ddName))
 	r.resultSignal <- dataPathResult{
 		err: errors.New(datapath.ErrCancelled),
 	}
@@ -283,12 +284,12 @@ func (r *RestoreMicroService) closeDataPath(ctx context.Context, ddName string) 
 func (r *RestoreMicroService) cancelDataDownload(dd *velerov2alpha1api.DataDownload) {
 	r.logger.WithField("DataDownload", dd.Name).Info("Data download is being canceled")
 
-	r.eventRecorder.Event(dd, false, datapath.EventReasonCancelling, "Canceling for data download %s", dd.Name)
+	r.eventRecorder.Event(dd, false, datapath.EventReasonCancelling, fmt.Sprintf("Canceling for data download %s", dd.Name))
 
 	fsBackup := r.dataPathMgr.GetAsyncBR(dd.Name)
 	if fsBackup == nil {
 		r.OnDataDownloadCancelled(r.ctx, dd.GetNamespace(), dd.GetName())
-		r.eventRecorder.EndingEvent(dd, false, datapath.EventReasonStopped, "Data path for %s exited without start", dd.Name)
+		r.eventRecorder.EndingEvent(dd, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s exited without start", dd.Name))
 	} else {
 		fsBackup.Cancel()
 	}

--- a/pkg/podvolume/backup_micro_service.go
+++ b/pkg/podvolume/backup_micro_service.go
@@ -19,6 +19,7 @@ package podvolume
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -202,7 +203,7 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 	}
 
 	log.Info("Async fs backup data path started")
-	r.eventRecorder.Event(pvb, false, datapath.EventReasonStarted, "Data path for %s started", pvb.Name)
+	r.eventRecorder.Event(pvb, false, datapath.EventReasonStarted, fmt.Sprintf("Data path for %s started", pvb.Name))
 
 	result := ""
 	select {
@@ -219,7 +220,7 @@ func (r *BackupMicroService) RunCancelableDataPath(ctx context.Context) (string,
 		log.WithError(err).Error("Async fs backup was not completed")
 	}
 
-	r.eventRecorder.EndingEvent(pvb, false, datapath.EventReasonStopped, "Data path for %s stopped", pvb.Name)
+	r.eventRecorder.EndingEvent(pvb, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s stopped", pvb.Name))
 
 	return result, err
 }
@@ -260,7 +261,7 @@ func (r *BackupMicroService) OnDataPathFailed(ctx context.Context, namespace str
 	log := r.logger.WithField("PVB", pvbName)
 	log.WithError(err).Error("Async fs backup data path failed")
 
-	r.eventRecorder.Event(r.pvb, false, datapath.EventReasonFailed, "Data path for PVB %s failed, error %v", r.pvbName, err)
+	r.eventRecorder.Event(r.pvb, false, datapath.EventReasonFailed, fmt.Sprintf("Data path for PVB %s failed, error %v", r.pvbName, err))
 	r.resultSignal <- dataPathResult{
 		err: errors.Wrapf(err, "Data path for PVB %s failed", r.pvbName),
 	}
@@ -270,7 +271,7 @@ func (r *BackupMicroService) OnDataPathCancelled(ctx context.Context, namespace 
 	log := r.logger.WithField("PVB", pvbName)
 	log.Warn("Async fs backup data path canceled")
 
-	r.eventRecorder.Event(r.pvb, false, datapath.EventReasonCancelled, "Data path for PVB %s canceled", pvbName)
+	r.eventRecorder.Event(r.pvb, false, datapath.EventReasonCancelled, fmt.Sprintf("Data path for PVB %s canceled", pvbName))
 	r.resultSignal <- dataPathResult{
 		err: errors.New(datapath.ErrCancelled),
 	}
@@ -302,12 +303,12 @@ func (r *BackupMicroService) closeDataPath(ctx context.Context, duName string) {
 func (r *BackupMicroService) cancelPodVolumeBackup(pvb *velerov1api.PodVolumeBackup) {
 	r.logger.WithField("PVB", pvb.Name).Info("PVB is being canceled")
 
-	r.eventRecorder.Event(pvb, false, datapath.EventReasonCancelling, "Canceling for PVB %s", pvb.Name)
+	r.eventRecorder.Event(pvb, false, datapath.EventReasonCancelling, fmt.Sprintf("Canceling for PVB %s", pvb.Name))
 
 	fsBackup := r.dataPathMgr.GetAsyncBR(pvb.Name)
 	if fsBackup == nil {
 		r.OnDataPathCancelled(r.ctx, pvb.GetNamespace(), pvb.GetName())
-		r.eventRecorder.EndingEvent(pvb, false, datapath.EventReasonStopped, "Data path for %s exited without start", pvb.Name)
+		r.eventRecorder.EndingEvent(pvb, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s exited without start", pvb.Name))
 	} else {
 		fsBackup.Cancel()
 	}

--- a/pkg/podvolume/backup_micro_service_test.go
+++ b/pkg/podvolume/backup_micro_service_test.go
@@ -54,22 +54,22 @@ type backupMsTestHelper struct {
 	eventLock    sync.Mutex
 }
 
-func (bt *backupMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (bt *backupMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string) {
 	bt.eventLock.Lock()
 	defer bt.eventLock.Unlock()
 
 	bt.withEvent = true
 	bt.eventReason = reason
-	bt.eventMsg = fmt.Sprintf(message, a...)
+	bt.eventMsg = message
 }
 
-func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (bt *backupMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string) {
 	bt.eventLock.Lock()
 	defer bt.eventLock.Unlock()
 
 	bt.withEvent = true
 	bt.eventReason = reason
-	bt.eventMsg = fmt.Sprintf(message, a...)
+	bt.eventMsg = message
 }
 func (bt *backupMsTestHelper) Shutdown() {}
 

--- a/pkg/podvolume/restore_micro_service.go
+++ b/pkg/podvolume/restore_micro_service.go
@@ -189,7 +189,7 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 	}
 
 	log.Info("Async fs restore data path started")
-	r.eventRecorder.Event(pvr, false, datapath.EventReasonStarted, "Data path for %s started", pvr.Name)
+	r.eventRecorder.Event(pvr, false, datapath.EventReasonStarted, fmt.Sprintf("Data path for %s started", pvr.Name))
 
 	result := ""
 	select {
@@ -206,7 +206,7 @@ func (r *RestoreMicroService) RunCancelableDataPath(ctx context.Context) (string
 		log.WithError(err).Error("Async fs restore was not completed")
 	}
 
-	r.eventRecorder.EndingEvent(pvr, false, datapath.EventReasonStopped, "Data path for %s stopped", pvr.Name)
+	r.eventRecorder.EndingEvent(pvr, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s stopped", pvr.Name))
 
 	return result, err
 }
@@ -265,7 +265,7 @@ func (r *RestoreMicroService) OnPvrCancelled(ctx context.Context, namespace stri
 	log := r.logger.WithField("PVR", pvrName)
 	log.Warn("Async fs restore data path canceled")
 
-	r.eventRecorder.Event(r.pvr, false, datapath.EventReasonCancelled, "Data path for PVR %s canceled", pvrName)
+	r.eventRecorder.Event(r.pvr, false, datapath.EventReasonCancelled, fmt.Sprintf("Data path for PVR %s canceled", pvrName))
 	r.resultSignal <- dataPathResult{
 		err: errors.New(datapath.ErrCancelled),
 	}
@@ -297,12 +297,12 @@ func (r *RestoreMicroService) closeDataPath(ctx context.Context, pvrName string)
 func (r *RestoreMicroService) cancelPodVolumeRestore(pvr *velerov1api.PodVolumeRestore) {
 	r.logger.WithField("PVR", pvr.Name).Info("PVR is being canceled")
 
-	r.eventRecorder.Event(pvr, false, datapath.EventReasonCancelling, "Canceling for PVR %s", pvr.Name)
+	r.eventRecorder.Event(pvr, false, datapath.EventReasonCancelling, fmt.Sprintf("Canceling for PVR %s", pvr.Name))
 
 	fsBackup := r.dataPathMgr.GetAsyncBR(pvr.Name)
 	if fsBackup == nil {
 		r.OnPvrCancelled(r.ctx, pvr.GetNamespace(), pvr.GetName())
-		r.eventRecorder.EndingEvent(pvr, false, datapath.EventReasonStopped, "Data path for %s exited without start", pvr.Name)
+		r.eventRecorder.EndingEvent(pvr, false, datapath.EventReasonStopped, fmt.Sprintf("Data path for %s exited without start", pvr.Name))
 	} else {
 		fsBackup.Cancel()
 	}

--- a/pkg/podvolume/restore_micro_service_test.go
+++ b/pkg/podvolume/restore_micro_service_test.go
@@ -58,22 +58,22 @@ type restoreMsTestHelper struct {
 	writeCompletionErr error
 }
 
-func (rt *restoreMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (rt *restoreMsTestHelper) Event(_ runtime.Object, _ bool, reason string, message string) {
 	rt.eventLock.Lock()
 	defer rt.eventLock.Unlock()
 
 	rt.withEvent = true
 	rt.eventReason = reason
-	rt.eventMsg = fmt.Sprintf(message, a...)
+	rt.eventMsg = message
 }
 
-func (rt *restoreMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string, a ...any) {
+func (rt *restoreMsTestHelper) EndingEvent(_ runtime.Object, _ bool, reason string, message string) {
 	rt.eventLock.Lock()
 	defer rt.eventLock.Unlock()
 
 	rt.withEvent = true
 	rt.eventReason = reason
-	rt.eventMsg = fmt.Sprintf(message, a...)
+	rt.eventMsg = message
 }
 func (rt *restoreMsTestHelper) Shutdown() {}
 

--- a/pkg/util/kube/event.go
+++ b/pkg/util/kube/event.go
@@ -31,8 +31,8 @@ import (
 )
 
 type EventRecorder interface {
-	Event(object runtime.Object, warning bool, reason string, message string, a ...any)
-	EndingEvent(object runtime.Object, warning bool, reason string, message string, a ...any)
+	Event(object runtime.Object, warning bool, reason string, message string)
+	EndingEvent(object runtime.Object, warning bool, reason string, message string)
 	Shutdown()
 }
 
@@ -84,7 +84,7 @@ func NewEventRecorder(kubeClient kubernetes.Interface, scheme *runtime.Scheme, e
 	return &res
 }
 
-func (er *eventRecorder) Event(object runtime.Object, warning bool, reason string, message string, a ...any) {
+func (er *eventRecorder) Event(object runtime.Object, warning bool, reason string, message string) {
 	if er.broadcaster == nil {
 		return
 	}
@@ -94,19 +94,15 @@ func (er *eventRecorder) Event(object runtime.Object, warning bool, reason strin
 		eventType = corev1api.EventTypeWarning
 	}
 
-	if len(a) > 0 {
-		er.recorder.Eventf(object, eventType, reason, message, a...)
-	} else {
-		er.recorder.Event(object, eventType, reason, message)
-	}
+	er.recorder.Event(object, eventType, reason, message)
 }
 
-func (er *eventRecorder) EndingEvent(object runtime.Object, warning bool, reason string, message string, a ...any) {
+func (er *eventRecorder) EndingEvent(object runtime.Object, warning bool, reason string, message string) {
 	if er.broadcaster == nil {
 		return
 	}
 
-	er.Event(object, warning, reason, message, a...)
+	er.Event(object, warning, reason, message)
 
 	var sentinelEvent string
 


### PR DESCRIPTION
## Summary

Go 1.26 introduced stricter `go vet` checks that flag non-constant format strings passed to functions with printf-like signatures (`string, ...any`). The `EventRecorder.Event` and `EndingEvent` methods had variadic signatures that triggered these warnings across 12 call sites in the datamover and podvolume packages.

This PR removes the variadic `a ...any` parameters from `Event` and `EndingEvent` (both the interface and implementations) and updates all callers to pre-format their messages with `fmt.Sprintf`. This eliminates the printf-like function signature that triggered the vet warnings while preserving identical runtime behavior.

## Changes

- Removed variadic `a ...any` from `EventRecorder` interface methods `Event` and `EndingEvent` in `pkg/util/kube/event.go`
- Simplified `eventRecorder.Event` implementation to always use `recorder.Event` (removed `Eventf` branch)
- Updated all callers in `pkg/datamover/` and `pkg/podvolume/` to use `fmt.Sprintf` for message formatting
- Updated test helper implementations to match the new interface signatures

## Test plan

- [x] `go build` passes for all affected packages
- [x] `go vet` passes for all affected packages (0 warnings)
- [x] `go test` passes for all affected packages (`pkg/util/kube`, `pkg/datamover`, `pkg/podvolume`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Kubernetes lifecycle event messages so dynamic details are properly included.
  - Improved accuracy of backup and restore status notifications, including start, stop, failure, cancellation, and early-exit events.

- **Refactor**
  - Standardized event message handling across data movement and volume operations for more consistent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->