### PR TITLE
Remove inactive users from DOWNSTREAM_OWNERS

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,19 +1,13 @@
 approvers:
   - jwmatthews
   - sseago
-  - jmontleon
   - shawn-hurley
-  - rayfordj
   - dymurray
   - shubham-pampattiwar
   - kaovilai
-  - eemcmullan
-  - savitharaghunathan
   - joeavaikath
 reviewers:
   - sseago
   - shubham-pampattiwar
   - kaovilai
-  - eemcmullan
-  - savitharaghunathan
   - joeavaikath


### PR DESCRIPTION
Remove inactive users from DOWNSTREAM_OWNERS approvers/reviewers.

---
@kaovilai requested in [Slack thread](https://redhat-internal.slack.com/archives/C0BHTAWB542/p1785509108887839)